### PR TITLE
Fix torrent status category

### DIFF
--- a/app.py
+++ b/app.py
@@ -261,7 +261,7 @@ def get_torrent_status(lottery_id):
     try:
         qbt_client = Client(host=QBIT_HOST, port=QBIT_PORT, username=QBIT_USERNAME, password=QBIT_PASSWORD)
         qbt_client.auth_log_in()
-        category = f"lottery-{lottery.id}"
+        category = f"lottery-{lottery_id}"
         torrents = qbt_client.torrents_info(category=category)
         if not torrents:
             return jsonify({"status": "not_found"})


### PR DESCRIPTION
## Summary
- ensure the torrent status endpoint builds the qBittorrent category using the provided lottery identifier to avoid NameError

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7e7aaa1c8328b90cc3b1f281b285