### PR TITLE
Improve lottery history details and downloads

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -368,12 +368,16 @@ button:disabled {
     color: #ced4da;
 }
 
-#modal-loser-list { text-align: left; margin-top: 25px; border-top: 1px solid #343a40; padding-top: 20px; }
-#modal-loser-list h3 { margin-bottom: 15px; }
-#modal-loser-list ul { padding-left: 0; list-style: none; display: grid; grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); gap: 15px; }
-.loser-item { display: flex; flex-direction: column; align-items: center; text-align: center; }
-.loser-poster { width: 100%; aspect-ratio: 2 / 3; object-fit: cover; border-radius: 5px; margin-bottom: 5px; box-shadow: 0 2px 5px rgba(0,0,0,0.4); }
-.loser-name { font-size: 12px; color: #adb5bd; }
+#modal-participants { text-align: left; margin-top: 25px; border-top: 1px solid #343a40; padding-top: 20px; }
+#modal-participants h3 { margin-bottom: 15px; }
+.participants-list { padding-left: 0; list-style: none; display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 15px; }
+.participant-item { display: flex; flex-direction: column; align-items: center; text-align: center; background-color: rgba(255, 255, 255, 0.03); padding: 10px; border-radius: 10px; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+.participant-item:hover { transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3); }
+.participant-item.winner { border: 1px solid var(--primary-color); box-shadow: 0 0 12px rgba(255, 193, 7, 0.4); }
+.participant-poster { width: 100%; aspect-ratio: 2 / 3; object-fit: cover; border-radius: 6px; margin-bottom: 8px; box-shadow: 0 2px 5px rgba(0,0,0,0.4); }
+.participant-name { font-size: 13px; color: #f1f3f5; margin-bottom: 4px; }
+.participant-meta { font-size: 11px; color: #adb5bd; }
+.participant-winner-badge { margin-top: 8px; font-size: 11px; font-weight: 700; color: var(--secondary-color); background-color: var(--primary-color); padding: 4px 8px; border-radius: 12px; }
 
 .action-button-tg { display: block; width: 100%; padding: 15px; font-size: 16px; font-weight: 700; text-align: center; text-decoration: none; background-color: #0088cc; color: white; border-radius: 8px; margin-top: 10px; transition: background-color 0.2s, transform 0.2s; }
 .action-button-tg:hover { background-color: #0099e6; transform: translateY(-2px); }
@@ -424,7 +428,22 @@ button:disabled {
 .widget-body {
     padding: 15px;
 }
-#widget-movie-name {
+
+.widget-empty {
+    font-size: 13px;
+    color: #adb5bd;
+    margin: 0 0 10px 0;
+}
+
+.widget-download {
+    margin-bottom: 18px;
+}
+
+.widget-download:last-child {
+    margin-bottom: 0;
+}
+
+.widget-download-title {
     font-size: 13px;
     white-space: nowrap;
     overflow: hidden;
@@ -453,6 +472,14 @@ button:disabled {
     font-size: 12px;
     color: #adb5bd;
     margin-top: 8px;
+}
+
+.widget-stats-bottom {
+    display: flex;
+    justify-content: flex-end;
+    font-size: 11px;
+    color: #868e96;
+    margin-top: 4px;
 }
 
 @media (max-width: 700px) {

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -5,39 +5,225 @@ document.addEventListener('DOMContentLoaded', () => {
     const modalOverlay = document.getElementById('history-modal');
     const closeButton = document.querySelector('.close-button');
     const modalWinnerInfo = document.getElementById('modal-winner-info');
-    const modalLoserListContainer = document.getElementById('modal-loser-list');
-    
-    const widget = document.getElementById('torrent-status-widget');
-    const widgetHeader = widget.querySelector('.widget-header');
-    const widgetMovieName = widget.querySelector('#widget-movie-name');
-    const widgetProgressBar = widget.querySelector('#widget-progress-bar');
-    const widgetProgressText = widget.querySelector('#widget-progress-text');
-    const widgetSpeedText = widget.querySelector('#widget-speed-text');
-    const widgetEtaText = widget.querySelector('#widget-eta-text');
-    // --- НОВОЕ: Элементы для сидов и пиров ---
-    const widgetPeersText = widget.querySelector('#widget-peers-text');
-    let statusPollInterval = null;
+    const modalParticipantsContainer = document.getElementById('modal-participants');
+    const modalParticipantsList = modalParticipantsContainer ? modalParticipantsContainer.querySelector('.participants-list') : null;
 
-    // --- ОБНОВЛЕННАЯ ЛОГИКА ВИДЖЕТА ---
-    const showWidget = (movieName) => {
-        widgetMovieName.textContent = `Загрузка: ${movieName}`;
-        widgetProgressBar.style.width = '0%';
-        widgetProgressText.textContent = '...';
-        widgetSpeedText.textContent = '';
-        widgetEtaText.textContent = '';
-        widgetPeersText.textContent = '';
-        widget.style.display = 'block';
-        widget.classList.remove('minimized');
+    const widget = document.getElementById('torrent-status-widget');
+    const widgetHeader = widget ? widget.querySelector('.widget-header') : null;
+    const widgetDownloadsContainer = widget ? widget.querySelector('#widget-downloads') : null;
+    const widgetEmptyText = widget ? widget.querySelector('.widget-empty') : null;
+
+    const ACTIVE_DOWNLOADS_KEY = 'lotteryActiveDownloads';
+    const pollIntervals = new Map();
+    const activeDownloads = new Map();
+
+    const saveActiveDownloads = () => {
+        if (!widget) return;
+        const payload = Array.from(activeDownloads.values()).map((entry) => ({
+            lotteryId: entry.lotteryId,
+            movieName: entry.movieName,
+            kinopoiskId: entry.kinopoiskId || null,
+        }));
+        localStorage.setItem(ACTIVE_DOWNLOADS_KEY, JSON.stringify(payload));
     };
 
-    const updateWidget = (data) => {
-        widgetMovieName.textContent = data.name;
-        widgetProgressText.textContent = `${data.progress}%`;
-        widgetProgressBar.style.width = `${data.progress}%`;
-        widgetSpeedText.textContent = `${data.speed} МБ/с`;
-        widgetEtaText.textContent = data.eta;
-        // --- НОВОЕ: Отображение сидов и пиров ---
-        widgetPeersText.textContent = `Сиды: ${data.seeds} / Пиры: ${data.peers}`;
+    const ensureWidgetState = () => {
+        if (!widget) return;
+        const hasDownloads = activeDownloads.size > 0;
+        widget.style.display = hasDownloads ? 'block' : 'none';
+        if (widgetEmptyText) widgetEmptyText.style.display = hasDownloads ? 'none' : 'block';
+        if (widgetDownloadsContainer) widgetDownloadsContainer.style.display = hasDownloads ? 'block' : 'none';
+        if (hasDownloads) {
+            widget.classList.remove('minimized');
+        }
+    };
+
+    const getOrCreateDownloadElement = (lotteryId) => {
+        if (!widgetDownloadsContainer) return null;
+        let item = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!item) {
+            item = document.createElement('div');
+            item.className = 'widget-download';
+            item.dataset.lotteryId = lotteryId;
+            item.innerHTML = `
+                <h5 class="widget-download-title"></h5>
+                <div class="progress-bar-container">
+                    <div class="progress-bar"></div>
+                </div>
+                <div class="widget-stats">
+                    <span class="progress-text">0%</span>
+                    <span class="speed-text">0.00 МБ/с</span>
+                    <span class="eta-text">--:--</span>
+                </div>
+                <div class="widget-stats-bottom">
+                    <span class="peers-text">Сиды: 0 / Пиры: 0</span>
+                </div>
+            `;
+            widgetDownloadsContainer.appendChild(item);
+        }
+        return item;
+    };
+
+    const registerDownload = (lotteryId, movieName, kinopoiskId, { skipSave = false } = {}) => {
+        if (!lotteryId) return;
+        const existing = activeDownloads.get(lotteryId) || {};
+        const updated = {
+            lotteryId,
+            movieName: movieName || existing.movieName || 'Загрузка...',
+            kinopoiskId: kinopoiskId || existing.kinopoiskId || null,
+        };
+        activeDownloads.set(lotteryId, updated);
+
+        const element = getOrCreateDownloadElement(lotteryId);
+        if (element) {
+            const title = element.querySelector('.widget-download-title');
+            if (title) {
+                title.textContent = `Загрузка: ${updated.movieName}`;
+            }
+        }
+
+        ensureWidgetState();
+        if (!skipSave) saveActiveDownloads();
+        return updated;
+    };
+
+    const removeDownload = (lotteryId) => {
+        if (pollIntervals.has(lotteryId)) {
+            clearInterval(pollIntervals.get(lotteryId));
+            pollIntervals.delete(lotteryId);
+        }
+        if (activeDownloads.has(lotteryId)) {
+            activeDownloads.delete(lotteryId);
+            saveActiveDownloads();
+        }
+        if (widgetDownloadsContainer) {
+            const element = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+            if (element) {
+                element.remove();
+            }
+        }
+        ensureWidgetState();
+    };
+
+    const updateDownloadView = (lotteryId, data) => {
+        if (!widgetDownloadsContainer) return;
+        const element = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!element) return;
+
+        const title = element.querySelector('.widget-download-title');
+        const bar = element.querySelector('.progress-bar');
+        const progressText = element.querySelector('.progress-text');
+        const speedText = element.querySelector('.speed-text');
+        const etaText = element.querySelector('.eta-text');
+        const peersText = element.querySelector('.peers-text');
+
+        if (data.name && title) {
+            title.textContent = `Загрузка: ${data.name}`;
+        }
+
+        if (data.status === 'error') {
+            if (progressText) progressText.textContent = 'Ошибка';
+            if (speedText) speedText.textContent = '-';
+            if (etaText) etaText.textContent = '-';
+            if (peersText) peersText.textContent = data.message || '';
+            if (bar) bar.style.width = '0%';
+            return;
+        }
+
+        if (data.status === 'not_found') {
+            if (progressText) progressText.textContent = 'Ожидание...';
+            if (speedText) speedText.textContent = '0.00 МБ/с';
+            if (etaText) etaText.textContent = '--:--';
+            if (peersText) peersText.textContent = 'Торрент не найден';
+            if (bar) bar.style.width = '0%';
+            return;
+        }
+
+        if (bar) bar.style.width = `${data.progress}%`;
+        if (progressText) progressText.textContent = `${data.progress}%`;
+        if (speedText) speedText.textContent = `${data.speed} МБ/с`;
+        if (etaText) etaText.textContent = data.eta;
+        if (peersText) peersText.textContent = `Сиды: ${data.seeds} / Пиры: ${data.peers}`;
+    };
+
+    const markDownloadCompleted = (lotteryId) => {
+        if (!widgetDownloadsContainer) return;
+        const element = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!element) return;
+
+        const bar = element.querySelector('.progress-bar');
+        const progressText = element.querySelector('.progress-text');
+        const speedText = element.querySelector('.speed-text');
+        const etaText = element.querySelector('.eta-text');
+        const peersText = element.querySelector('.peers-text');
+
+        if (bar) bar.style.width = '100%';
+        if (progressText) progressText.textContent = '100%';
+        if (speedText) speedText.textContent = 'Готово';
+        if (etaText) etaText.textContent = '--';
+        if (peersText) peersText.textContent = 'Раздача';
+
+        setTimeout(() => removeDownload(lotteryId), 5000);
+    };
+
+    const startTorrentStatusPolling = (lotteryId, movieName, kinopoiskId) => {
+        if (!lotteryId) return;
+        registerDownload(lotteryId, movieName, kinopoiskId);
+
+        if (pollIntervals.has(lotteryId)) {
+            clearInterval(pollIntervals.get(lotteryId));
+        }
+
+        const poll = async () => {
+            try {
+                const response = await fetch(`/api/torrent-status/${lotteryId}`);
+                const data = await response.json();
+
+                if (data.status === 'error') {
+                    updateDownloadView(lotteryId, data);
+                    if (pollIntervals.has(lotteryId)) {
+                        clearInterval(pollIntervals.get(lotteryId));
+                        pollIntervals.delete(lotteryId);
+                    }
+                    return;
+                }
+
+                updateDownloadView(lotteryId, data);
+
+                if (data.status && (data.status.includes('seeding') || data.status.includes('completed') || parseFloat(data.progress) >= 100)) {
+                    if (pollIntervals.has(lotteryId)) {
+                        clearInterval(pollIntervals.get(lotteryId));
+                        pollIntervals.delete(lotteryId);
+                    }
+                    markDownloadCompleted(lotteryId);
+                }
+            } catch (error) {
+                console.error('Ошибка при опросе статуса торрента:', error);
+                updateDownloadView(lotteryId, { status: 'error', message: 'Нет связи с qBittorrent' });
+                if (pollIntervals.has(lotteryId)) {
+                    clearInterval(pollIntervals.get(lotteryId));
+                    pollIntervals.delete(lotteryId);
+                }
+            }
+        };
+
+        poll();
+        const intervalId = setInterval(poll, 3000);
+        pollIntervals.set(lotteryId, intervalId);
+    };
+
+    const initializeStoredDownloads = () => {
+        if (!widget) return;
+        try {
+            const stored = JSON.parse(localStorage.getItem(ACTIVE_DOWNLOADS_KEY) || '[]');
+            stored.forEach((entry) => {
+                if (!entry || !entry.lotteryId) return;
+                startTorrentStatusPolling(entry.lotteryId, entry.movieName, entry.kinopoiskId);
+            });
+        } catch (error) {
+            console.warn('Не удалось восстановить активные загрузки:', error);
+            localStorage.removeItem(ACTIVE_DOWNLOADS_KEY);
+        }
     };
 
     if (widgetHeader) {
@@ -46,31 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const startTorrentStatusPolling = (lotteryId, movieName) => {
-        if (statusPollInterval) clearInterval(statusPollInterval);
-        showWidget(movieName);
-        
-        const poll = async () => {
-            try {
-                const response = await fetch(`/api/torrent-status/${lotteryId}`);
-                const data = await response.json();
-
-                if (data.status !== 'not_found' && data.status !== 'error') {
-                    updateWidget(data);
-                    if (data.status.includes('seeding') || data.status.includes('completed') || parseFloat(data.progress) >= 100) {
-                        clearInterval(statusPollInterval);
-                    }
-                }
-            } catch (error) {
-                console.error("Ошибка при опросе статуса торрента:", error);
-                clearInterval(statusPollInterval);
-            }
-        };
-        poll();
-        statusPollInterval = setInterval(poll, 3000);
-    };
-
-    // --- НОВАЯ ЛОГИКА ВЗАИМОДЕЙСТВИЯ ---
+    // --- ЛОГИКА ВЗАИМОДЕЙСТВИЯ С КНОПКАМИ КАРТОЧЕК ---
 
     const handleSearchClick = (movieName, movieYear) => {
         const query = encodeURIComponent(`${movieName} (${movieYear})`);
@@ -79,23 +241,23 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const handleDownloadClick = async (kinopoiskId, movieName, lotteryId) => {
-        showWidget(movieName);
+        registerDownload(lotteryId, movieName, kinopoiskId);
         try {
             const response = await fetch(`/api/start-download/${kinopoiskId}`, { method: 'POST' });
             const data = await response.json();
             if (data.success) {
-                startTorrentStatusPolling(lotteryId, movieName);
+                startTorrentStatusPolling(lotteryId, movieName, kinopoiskId);
             } else {
                 alert(`Ошибка: ${data.message}`);
-                widget.style.display = 'none';
+                removeDownload(lotteryId);
             }
         } catch (error) {
             console.error('Ошибка при запуске скачивания:', error);
             alert('Произошла критическая ошибка.');
-            widget.style.display = 'none';
+            removeDownload(lotteryId);
         }
     };
-    
+
     const handleSaveMagnet = async (kinopoiskId, magnetLink) => {
         try {
             const response = await fetch('/api/movie-magnet', {
@@ -105,9 +267,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             const data = await response.json();
             alert(data.message);
-            if(data.success) {
+            if (data.success) {
                 closeModal();
-                location.reload(); // Перезагружаем страницу для обновления кнопок
+                location.reload();
             }
         } catch (error) {
             console.error('Ошибка при сохранении magnet-ссылки:', error);
@@ -115,7 +277,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    // --- ОБНОВЛЕННАЯ ЛОГИКА УДАЛЕНИЯ ---
     const handleDeleteLottery = async (lotteryId, cardElement) => {
         if (!confirm('Вы уверены, что хотите удалить эту лотерею? Торрент и скачанные файлы также будут удалены из qBittorrent.')) {
             return;
@@ -126,9 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
             alert(data.message);
             if (data.success) {
                 cardElement.classList.add('is-deleting');
-                // ИЗМЕНЕНИЕ: Скрываем виджет и останавливаем опрос
-                if (statusPollInterval) clearInterval(statusPollInterval);
-                widget.style.display = 'none';
+                removeDownload(lotteryId);
                 setTimeout(() => cardElement.remove(), 500);
             }
         } catch (error) {
@@ -136,18 +295,56 @@ document.addEventListener('DOMContentLoaded', () => {
             alert('Не удалось удалить лотерею.');
         }
     };
-    
-    // --- ОБНОВЛЕННАЯ ЛОГИКА МОДАЛЬНОГО ОКНА ---
+
+    // --- МОДАЛЬНОЕ ОКНО ---
+
+    const renderParticipantsList = (movies, winnerName) => {
+        if (!modalParticipantsContainer || !modalParticipantsList) return;
+        if (!movies || !movies.length) {
+            modalParticipantsContainer.style.display = 'none';
+            modalParticipantsList.innerHTML = '';
+            return;
+        }
+
+        modalParticipantsContainer.style.display = 'block';
+        modalParticipantsList.innerHTML = '';
+
+        movies.forEach((movie) => {
+            const item = document.createElement('li');
+            item.className = 'participant-item';
+            if (movie.name === winnerName) {
+                item.classList.add('winner');
+            }
+
+            item.innerHTML = `
+                <img class="participant-poster" src="${movie.poster || 'https://via.placeholder.com/100x150.png?text=No+Image'}" alt="${movie.name}">
+                <span class="participant-name">${movie.name}</span>
+                <span class="participant-meta">${movie.year || ''}</span>
+                ${movie.name === winnerName ? '<span class="participant-winner-badge">Победитель</span>' : ''}
+            `;
+
+            modalParticipantsList.appendChild(item);
+        });
+    };
+
     const openModal = async (lotteryId) => {
+        if (!modalOverlay) return;
         modalOverlay.style.display = 'flex';
         modalWinnerInfo.innerHTML = '<div class="loader"></div>';
-        modalLoserListContainer.style.display = 'none';
+        if (modalParticipantsContainer) {
+            modalParticipantsContainer.style.display = 'none';
+        }
+        if (modalParticipantsList) {
+            modalParticipantsList.innerHTML = '';
+        }
 
         try {
             const response = await fetch(`/api/result/${lotteryId}`);
             if (!response.ok) throw new Error('Ошибка сети');
             const data = await response.json();
             if (data.error) throw new Error(data.error);
+
+            renderParticipantsList(data.movies || [], data.result ? data.result.name : null);
 
             if (data.result) {
                 renderWinnerCard(data.result);
@@ -170,24 +367,29 @@ document.addEventListener('DOMContentLoaded', () => {
                     </a>
                 `;
 
-                modalWinnerInfo.querySelector('.copy-btn').addEventListener('click', (e) => {
-                    const targetId = e.target.dataset.target;
-                    const input = document.getElementById(targetId);
-                    input.select();
-                    document.execCommand('copy');
-                    e.target.textContent = 'Скопировано!';
-                    setTimeout(() => { e.target.textContent = 'Копировать'; }, 2000);
-                });
+                const copyBtn = modalWinnerInfo.querySelector('.copy-btn');
+                if (copyBtn) {
+                    copyBtn.addEventListener('click', (e) => {
+                        const targetId = e.target.dataset.target;
+                        const input = document.getElementById(targetId);
+                        if (!input) return;
+                        input.select();
+                        document.execCommand('copy');
+                        e.target.textContent = 'Скопировано!';
+                        setTimeout(() => { e.target.textContent = 'Копировать'; }, 2000);
+                    });
+                }
             }
         } catch (error) {
             modalWinnerInfo.innerHTML = `<p class="error-message">Не удалось загрузить детали: ${error.message}</p>`;
         }
     };
-    
+
     const renderWinnerCard = (winner) => {
-        const ratingClass = winner.rating_kp >= 7 ? 'rating-high' : winner.rating_kp >= 5 ? 'rating-medium' : 'rating-low';
-        const ratingBadgeHtml = winner.rating_kp ? `<div class="rating-badge ${ratingClass}">${winner.rating_kp.toFixed(1)}</div>` : '';
-        
+        const ratingValue = typeof winner.rating_kp === 'number' ? winner.rating_kp : 0;
+        const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
+        const ratingBadgeHtml = ratingValue ? `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>` : '';
+
         const magnetFormHtml = `
             <div class="magnet-form">
                 <label for="magnet-input">Magnet-ссылка:</label>
@@ -214,29 +416,30 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
         `;
 
-        modalWinnerInfo.querySelector('.save-magnet-btn').addEventListener('click', () => {
-            const input = modalWinnerInfo.querySelector('#magnet-input');
-            handleSaveMagnet(winner.kinopoisk_id, input.value);
-        });
+        const saveBtn = modalWinnerInfo.querySelector('.save-magnet-btn');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', () => {
+                const input = modalWinnerInfo.querySelector('#magnet-input');
+                handleSaveMagnet(winner.kinopoisk_id, input ? input.value : '');
+            });
+        }
 
         const deleteBtn = modalWinnerInfo.querySelector('.delete-magnet-btn');
         if (deleteBtn) {
             deleteBtn.addEventListener('click', () => {
                 if (confirm('Вы уверены, что хотите удалить сохраненную magnet-ссылку?')) {
-                    handleSaveMagnet(winner.kinopoisk_id, ''); // Отправляем пустую строку для удаления
+                    handleSaveMagnet(winner.kinopoisk_id, '');
                 }
             });
         }
     };
 
-    // --- ОБНОВЛЕННЫЙ ОБРАБОТЧИК КЛИКОВ В ГАЛЕРЕЕ ---
     if (gallery) {
         gallery.addEventListener('click', (e) => {
             const galleryItem = e.target.closest('.gallery-item');
             if (!galleryItem) return;
 
             const { lotteryId, kinopoiskId, movieName, movieYear } = galleryItem.dataset;
-
             const isDownloadButton = e.target.classList.contains('download-button');
             const isSearchButton = e.target.classList.contains('search-button');
             const isDeleteButton = e.target.classList.contains('delete-button');
@@ -255,7 +458,94 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const closeModal = () => { if(modalOverlay) modalOverlay.style.display = 'none'; };
+    const closeModal = () => {
+        if (modalOverlay) {
+            modalOverlay.style.display = 'none';
+        }
+    };
+
     if (closeButton) closeButton.addEventListener('click', closeModal);
-    if (modalOverlay) modalOverlay.addEventListener('click', (e) => { if (e.target === modalOverlay) closeModal(); });
+    if (modalOverlay) {
+        modalOverlay.addEventListener('click', (e) => {
+            if (e.target === modalOverlay) closeModal();
+        });
+    }
+
+    // --- АВТОМАТИЧЕСКОЕ ОБНОВЛЕНИЕ ОЖИДАЮЩИХ ЛОТЕРЕЙ ---
+
+    const waitingCards = new Map();
+    let waitingIntervalId = null;
+    const collectWaitingCards = () => {
+        document.querySelectorAll('.waiting-card').forEach((card) => {
+            const lotteryId = card.dataset.lotteryId;
+            if (lotteryId) {
+                waitingCards.set(lotteryId, card);
+            }
+        });
+    };
+
+    const createCompletedCard = (lotteryId, winner, createdAt) => {
+        const item = document.createElement('div');
+        item.className = 'gallery-item';
+        item.dataset.lotteryId = lotteryId;
+        item.dataset.kinopoiskId = winner.kinopoisk_id || '';
+        item.dataset.movieName = winner.name || '';
+        item.dataset.movieYear = winner.year || '';
+
+        const actionButton = winner.has_magnet
+            ? '<button class="action-button download-button" title="Скачать фильм">&#x2913;</button>'
+            : '<button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>';
+
+        item.innerHTML = `
+            <div class="action-buttons">
+                ${actionButton}
+                <button class="action-button-delete delete-button" title="Удалить лотерею">&times;</button>
+            </div>
+            <img src="${winner.poster || 'https://via.placeholder.com/200x300.png?text=No+Image'}" alt="${winner.name}">
+            <div class="date-overlay" data-date="${createdAt}"></div>
+        `;
+
+        return item;
+    };
+
+    const pollWaitingCards = async () => {
+        if (!waitingCards.size) {
+            if (waitingIntervalId) {
+                clearInterval(waitingIntervalId);
+                waitingIntervalId = null;
+            }
+            return;
+        }
+
+        const checkCard = async (lotteryId, cardElement) => {
+            try {
+                const response = await fetch(`/api/result/${lotteryId}`);
+                if (!response.ok) return;
+                const data = await response.json();
+                if (data.result) {
+                    const newCard = createCompletedCard(lotteryId, data.result, data.createdAt);
+                    cardElement.replaceWith(newCard);
+                    waitingCards.delete(lotteryId);
+                }
+            } catch (error) {
+                console.error('Не удалось обновить лотерею', lotteryId, error);
+            }
+        };
+
+        await Promise.all(Array.from(waitingCards.entries()).map(([lotteryId, card]) => checkCard(lotteryId, card)));
+
+        if (!waitingCards.size && waitingIntervalId) {
+            clearInterval(waitingIntervalId);
+            waitingIntervalId = null;
+        }
+    };
+
+    collectWaitingCards();
+    if (waitingCards.size) {
+        pollWaitingCards();
+        waitingIntervalId = setInterval(pollWaitingCards, 5000);
+    }
+
+    initializeStoredDownloads();
+    ensureWidgetState();
 });

--- a/templates/history.html
+++ b/templates/history.html
@@ -67,9 +67,9 @@
         <div class="modal-content">
             <span class="close-button">&times;</span>
             <div id="modal-winner-info"></div>
-            <div id="modal-loser-list" style="display: none;">
-                 <h3>Проигравшие варианты:</h3>
-                 <ul></ul>
+            <div id="modal-participants" style="display: none;">
+                <h3>Участники лотереи</h3>
+                <ul class="participants-list"></ul>
             </div>
         </div>
     </div>
@@ -81,18 +81,8 @@
             <button id="widget-toggle-btn" class="widget-toggle-btn">&mdash;</button>
         </div>
         <div id="widget-body" class="widget-body">
-            <p id="widget-movie-name">Название фильма...</p>
-            <div class="progress-bar-container">
-                <div id="widget-progress-bar" class="progress-bar"></div>
-            </div>
-            <div class="widget-stats">
-                <span id="widget-progress-text">0%</span>
-                <span id="widget-speed-text">0.00 МБ/с</span>
-                <span id="widget-eta-text">--:--</span>
-            </div>
-             <div class="widget-stats-bottom">
-                <span id="widget-peers-text">Сиды: 0 / Пиры: 0</span>
-            </div>
+            <p class="widget-empty">Активных загрузок нет.</p>
+            <div id="widget-downloads"></div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- show every movie that took part in a lottery inside the history modal and highlight the winner
- add polling so waiting lotteries in the gallery flip to their result automatically once a draw happens
- redesign the download status widget to support multiple simultaneous torrents and persist them between visits

## Testing
- pytest *(fails: tests/test_torrent_status.py contains invalid shell snippet and raises SyntaxError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68cf79fd70e08328bf5ab92a1da86746