### PR TITLE
Fix library template identifier handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,21 @@ class Movie(db.Model):
     rating_kp = db.Column(db.Float, nullable=True)
     genres = db.Column(db.String(200), nullable=True)
     countries = db.Column(db.String(200), nullable=True)
-    
+
+
+class LibraryMovie(db.Model):
+    __tablename__ = 'library_movie'
+    id = db.Column(db.Integer, primary_key=True)
+    kinopoisk_id = db.Column(db.Integer, unique=True, nullable=True)
+    name = db.Column(db.String(200), nullable=False)
+    poster = db.Column(db.String(500), nullable=True)
+    year = db.Column(db.String(10), nullable=True)
+    description = db.Column(db.Text, nullable=True)
+    rating_kp = db.Column(db.Float, nullable=True)
+    genres = db.Column(db.String(200), nullable=True)
+    countries = db.Column(db.String(200), nullable=True)
+    added_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
 class BackgroundPhoto(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     poster_url = db.Column(db.String(500), unique=True, nullable=False)
@@ -119,6 +133,24 @@ def get_background_photos():
     except ProgrammingError:
         return []
 
+
+def ensure_background_photo(poster_url):
+    if not poster_url:
+        return
+
+    if BackgroundPhoto.query.filter_by(poster_url=poster_url).first():
+        return
+
+    max_z_index = db.session.query(db.func.max(BackgroundPhoto.z_index)).scalar() or 0
+    new_photo = BackgroundPhoto(
+        poster_url=poster_url,
+        pos_top=random.uniform(5, 65),
+        pos_left=random.uniform(5, 75),
+        rotation=random.randint(-30, 30),
+        z_index=max_z_index + 1,
+    )
+    db.session.add(new_photo)
+
 # --- Маршруты ---
 @app.route('/')
 def index():
@@ -150,14 +182,10 @@ def create_lottery():
         )
         db.session.add(new_movie)
     
-    max_z_index = db.session.query(db.func.max(BackgroundPhoto.z_index)).scalar() or 0
     for movie_data in movies_json:
         if poster := movie_data.get('poster'):
-            if not BackgroundPhoto.query.filter_by(poster_url=poster).first():
-                max_z_index += 1
-                new_photo = BackgroundPhoto(poster_url=poster, pos_top=random.uniform(5, 65), pos_left=random.uniform(5, 75), rotation=random.randint(-30, 30), z_index=max_z_index)
-                db.session.add(new_photo)
-    
+            ensure_background_photo(poster)
+
     db.session.commit()
     return jsonify({"wait_url": url_for('wait_for_result', lottery_id=new_lottery.id)})
 
@@ -189,9 +217,24 @@ def history():
 
     # Передаем в шаблон и лотереи, и словарь с magnet-ссылками
     return render_template(
-        'history.html', 
-        lotteries=lotteries, 
+        'history.html',
+        lotteries=lotteries,
         identifiers=identifiers,
+        background_photos=get_background_photos()
+    )
+
+
+@app.route('/library')
+def library():
+    library_movies = LibraryMovie.query.order_by(LibraryMovie.added_at.desc()).all()
+    for movie in library_movies:
+        if movie.kinopoisk_id:
+            movie.identifier = MovieIdentifier.query.get(movie.kinopoisk_id)
+        else:
+            movie.identifier = None
+    return render_template(
+        'library.html',
+        library_movies=library_movies,
         background_photos=get_background_photos()
     )
 
@@ -221,13 +264,115 @@ def get_result_data(lottery_id):
     for m in lottery.movies:
         identifier = MovieIdentifier.query.get(m.kinopoisk_id)
         movies_data.append({
-            "kinopoisk_id": m.kinopoisk_id, "name": m.name, "poster": m.poster, "year": m.year, 
+            "kinopoisk_id": m.kinopoisk_id, "name": m.name, "poster": m.poster, "year": m.year,
             "description": m.description, "rating_kp": m.rating_kp, "genres": m.genres, "countries": m.countries,
             "has_magnet": bool(identifier), "magnet_link": identifier.magnet_link if identifier else None
         })
 
     result_data = next((m for m in movies_data if m["name"] == lottery.result_name), None) if lottery.result_name else None
     return jsonify({"movies": movies_data, "result": result_data, "createdAt": lottery.created_at.isoformat() + "Z", "play_url": url_for('play_lottery', lottery_id=lottery.id, _external=True)})
+
+
+@app.route('/api/library', methods=['POST'])
+def add_library_movie():
+    payload = request.json or {}
+    movie_data = payload.get('movie') if isinstance(payload.get('movie'), dict) else payload
+
+    if not movie_data:
+        return jsonify({"success": False, "message": "Данные о фильме не переданы."}), 400
+
+    kinopoisk_id = movie_data.get('kinopoisk_id')
+    name = movie_data.get('name')
+    year = movie_data.get('year')
+    if isinstance(year, str) and year.lower() in ('', 'none', 'null'):
+        year = None
+
+    source_movie = None
+    if kinopoisk_id:
+        source_movie = Movie.query.filter_by(kinopoisk_id=kinopoisk_id).order_by(Movie.id.desc()).first()
+    elif movie_data.get('lottery_id') and movie_data.get('name'):
+        source_movie = Movie.query.filter_by(lottery_id=movie_data['lottery_id'], name=movie_data['name']).first()
+
+    if source_movie:
+        movie_data = {
+            **{k: v for k, v in movie_data.items() if v not in (None, '')},
+            "kinopoisk_id": kinopoisk_id or source_movie.kinopoisk_id,
+            "name": name or source_movie.name,
+            "poster": movie_data.get('poster') or source_movie.poster,
+            "year": year or source_movie.year,
+            "description": movie_data.get('description') or source_movie.description,
+            "rating_kp": movie_data.get('rating_kp') if movie_data.get('rating_kp') not in (None, '') else source_movie.rating_kp,
+            "genres": movie_data.get('genres') or source_movie.genres,
+            "countries": movie_data.get('countries') or source_movie.countries,
+        }
+        kinopoisk_id = movie_data.get('kinopoisk_id')
+        name = movie_data.get('name')
+        year = movie_data.get('year')
+
+    if not name:
+        return jsonify({"success": False, "message": "Не удалось определить название фильма."}), 400
+
+    existing = None
+    if kinopoisk_id:
+        existing = LibraryMovie.query.filter_by(kinopoisk_id=kinopoisk_id).first()
+    if not existing:
+        existing = LibraryMovie.query.filter_by(name=name, year=year).first()
+
+    message = "Фильм добавлен в библиотеку."
+
+    poster_after_update = None
+
+    if existing:
+        existing.name = name
+        if movie_data.get('poster'): existing.poster = movie_data['poster']
+        if year: existing.year = year
+        if movie_data.get('description'): existing.description = movie_data['description']
+        if movie_data.get('rating_kp') not in (None, ''):
+            try:
+                existing.rating_kp = float(movie_data['rating_kp'])
+            except (TypeError, ValueError):
+                pass
+        if movie_data.get('genres'): existing.genres = movie_data['genres']
+        if movie_data.get('countries'): existing.countries = movie_data['countries']
+        if kinopoisk_id: existing.kinopoisk_id = kinopoisk_id
+        existing.added_at = datetime.utcnow()
+        message = "Информация о фильме обновлена в библиотеке."
+        poster_after_update = existing.poster
+    else:
+        rating_value = None
+        raw_rating = movie_data.get('rating_kp')
+        if raw_rating not in (None, ''):
+            try:
+                rating_value = float(raw_rating)
+            except (TypeError, ValueError):
+                rating_value = None
+
+        new_movie = LibraryMovie(
+            kinopoisk_id=kinopoisk_id,
+            name=name,
+            poster=movie_data.get('poster'),
+            year=year,
+            description=movie_data.get('description'),
+            rating_kp=rating_value,
+            genres=movie_data.get('genres'),
+            countries=movie_data.get('countries'),
+        )
+        db.session.add(new_movie)
+        poster_after_update = new_movie.poster
+
+    if poster_after_update:
+        ensure_background_photo(poster_after_update)
+
+    db.session.commit()
+    return jsonify({"success": True, "message": message})
+
+
+@app.route('/api/library/<int:movie_id>', methods=['DELETE'])
+def remove_library_movie(movie_id):
+    library_movie = LibraryMovie.query.get_or_404(movie_id)
+    db.session.delete(library_movie)
+    db.session.commit()
+    return jsonify({"success": True, "message": "Фильм удален из библиотеки."})
 
 # --- ОБНОВЛЕННЫЙ МАРШРУТ УДАЛЕНИЯ ---
 @app.route('/delete-lottery/<lottery_id>', methods=['POST'])
@@ -273,6 +418,8 @@ def save_movie_magnet():
         return jsonify({"success": False, "message": "Отсутствует ID фильма"}), 400
 
     identifier = MovieIdentifier.query.get(kinopoisk_id)
+    magnet_link = (magnet_link or '').strip()
+
     if magnet_link:
         if identifier:
             identifier.magnet_link = magnet_link
@@ -285,9 +432,15 @@ def save_movie_magnet():
         message = "Magnet-ссылка удалена."
     else:
         message = "Действий не требуется."
-        
+
     db.session.commit()
-    return jsonify({"success": True, "message": message})
+    refreshed_identifier = MovieIdentifier.query.get(kinopoisk_id)
+    return jsonify({
+        "success": True,
+        "message": message,
+        "has_magnet": bool(refreshed_identifier),
+        "magnet_link": refreshed_identifier.magnet_link if refreshed_identifier else "",
+    })
 
 
 @app.route('/api/start-download/<int:kinopoisk_id>', methods=['POST'])
@@ -299,8 +452,12 @@ def start_download(kinopoisk_id):
     try:
         qbt_client = Client(host=QBIT_HOST, port=QBIT_PORT, username=QBIT_USERNAME, password=QBIT_PASSWORD)
         qbt_client.auth_log_in()
-        # ИЗМЕНЕНИЕ: Заменяем 'is_sequential' на правильный параметр 'sequential=True'
-        qbt_client.torrents_add(urls=identifier.magnet_link, category=category, sequential=True)
+        qbt_client.torrents_add(
+            urls=identifier.magnet_link,
+            category=category,
+            is_sequential_download=True,
+            is_first_last_piece_priority=True,
+        )
         qbt_client.auth_log_out()
         return jsonify({"success": True, "message": "Загрузка началась!"})
     except Exception as e:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -97,6 +97,12 @@ header p {
     transform: translateY(-2px);
     border-color: #495057;
 }
+.nav-links {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
 
 .input-group {
     display: flex;
@@ -161,12 +167,17 @@ button:disabled {
     position: relative;
     overflow: hidden;
     transition: transform 0.3s;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 .movie-card:hover { transform: scale(1.05); }
 .movie-card img { width: 100%; border-radius: 5px; }
 .movie-card .movie-info h4 { margin: 10px 0 5px; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .movie-card .movie-info p { margin: 0; font-size: 12px; color: #adb5bd; }
-.remove-btn { position: absolute; top: 5px; right: 5px; background: rgba(0,0,0,0.7); color: white; border: none; border-radius: 50%; width: 25px; height: 25px; font-size: 16px; line-height: 25px; text-align: center; padding: 0; cursor: pointer; opacity: 0; transition: opacity 0.3s; }
+.movie-card-actions { margin-top: auto; }
+.movie-card-actions .secondary-button { width: 100%; }
+.remove-btn { position: absolute; top: 5px; right: 5px; background: rgba(0,0,0,0.7); color: white; border: none; border-radius:50%; width: 25px; height: 25px; font-size: 16px; line-height: 25px; text-align: center; padding: 0; cursor: pointer; opacity: 0; transition: opacity 0.3s; }
 .movie-card:hover .remove-btn { opacity: 1; }
 
 .link-box { margin-bottom: 10px; text-align: left; display: flex; flex-wrap: wrap; gap: 10px; }
@@ -255,6 +266,13 @@ button:disabled {
 /* СТИЛИ ГАЛЕРЕИ И МОДАЛЬНОГО ОКНА */
 .gallery-body { padding: 0; }
 .gallery-header { padding: 20px; text-align: center; position: relative; z-index: 1; }
+.gallery-actions {
+    margin-top: 15px;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+}
 .history-gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 8px; padding: 8px; position: relative; z-index: 1; }
 .gallery-item, .waiting-card { position: relative; overflow: hidden; cursor: pointer; border-radius: 8px; box-shadow: 0 4px 15px rgba(0,0,0,0.5); aspect-ratio: 2 / 3; transition: transform 0.3s ease, opacity 0.5s ease; }
 .gallery-item.is-deleting, .waiting-card.is-deleting { transform: scale(0.9); opacity: 0; }
@@ -297,8 +315,26 @@ button:disabled {
 
 .gallery-item img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform 0.4s ease, filter 0.4s ease; animation: reveal 0.5s ease-out forwards; }
 .gallery-item:hover img { transform: scale(1.05); filter: brightness(1.1); }
-.date-overlay { position: absolute; bottom: 0; left: 0; width: 100%; background: linear-gradient(to top, rgba(0,0,0,0.8), transparent); color: white; padding: 20px 10px 10px; font-size: 14px; font-weight: 700; text-align: left; transition: opacity 0.4s; pointer-events: none; }
-.gallery-item:hover .date-overlay, .waiting-card:hover .date-overlay { opacity: 0; }
+.date-badge {
+    position: absolute;
+    top: 48px;
+    right: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 20px;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: white;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 2;
+}
+.gallery-item:hover .date-badge, .waiting-card:hover .date-badge { opacity: 0; }
+.date-badge .calendar-icon { font-size: 15px; }
 .no-history { grid-column: 1 / -1; text-align: center; font-size: 1.2em; color: #adb5bd; padding: 50px; }
 .waiting-card { background-color: #2b2b2b; display: flex; justify-content: center; align-items: center; text-align: center; color: #adb5bd; transition: background-color 0.4s; }
 .waiting-card:hover { background-color: #343a40; }
@@ -306,6 +342,115 @@ button:disabled {
 .waiting-card.is-updating .waiting-content { opacity: 0; }
 .waiting-content .loader-small { border: 3px solid #6c757d; border-top: 3px solid var(--primary-color); border-radius: 50%; width: 30px; height: 30px; animation: spin 1s linear infinite; margin: 0 auto 10px; }
 .waiting-content span { font-weight: 700; }
+.waiting-card .date-badge { top: 12px; }
+
+.library-gallery { margin-top: 10px; }
+.library-gallery .gallery-item {
+    background: linear-gradient(160deg, rgba(18, 18, 18, 0.95), rgba(33, 33, 33, 0.85));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+}
+.library-gallery .gallery-item.has-magnet {
+    border-color: rgba(40, 167, 69, 0.45);
+    box-shadow: 0 14px 32px rgba(40, 167, 69, 0.25);
+}
+.library-gallery .library-primary-action {
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    background-color: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(6px);
+    transition: background-color 0.3s ease, transform 0.3s ease;
+}
+.library-gallery .library-primary-action.search-button:hover {
+    background-color: rgba(0, 123, 255, 0.75);
+}
+.library-gallery .library-primary-action.download-button {
+    background-color: rgba(40, 167, 69, 0.65);
+}
+.library-gallery .library-primary-action.download-button:hover {
+    background-color: rgba(40, 167, 69, 0.85);
+}
+.library-gallery .library-primary-action.is-busy {
+    pointer-events: none;
+    opacity: 0.7;
+}
+.library-remove-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: linear-gradient(135deg, rgba(220, 53, 69, 0.92), rgba(108, 0, 15, 0.85));
+    box-shadow: 0 10px 24px rgba(220, 53, 69, 0.35);
+    color: #fff;
+    font-size: 24px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+.library-remove-btn:hover {
+    transform: translateY(-2px) scale(1.05);
+    box-shadow: 0 14px 30px rgba(220, 53, 69, 0.45);
+    background: linear-gradient(135deg, rgba(255, 82, 97, 0.95), rgba(157, 22, 35, 0.9));
+}
+.library-item.has-magnet::after {
+    content: 'Magnet';
+    position: absolute;
+    left: 10px;
+    bottom: 10px;
+    padding: 4px 10px;
+    font-size: 11px;
+    letter-spacing: 0.6px;
+    background: rgba(40, 167, 69, 0.85);
+    color: var(--secondary-color);
+    border-radius: 999px;
+    font-weight: 700;
+    text-transform: uppercase;
+    box-shadow: 0 6px 12px rgba(40, 167, 69, 0.35);
+}
+.magnet-feedback {
+    font-size: 13px;
+    color: #adb5bd;
+    margin: 0;
+}
+.magnet-feedback.is-success { color: var(--rating-high); }
+.magnet-feedback.is-error { color: var(--danger-color); }
+.magnet-unavailable {
+    margin-top: 20px;
+    font-size: 14px;
+    color: #ffb84d;
+    background: rgba(255, 193, 7, 0.1);
+    border: 1px solid rgba(255, 193, 7, 0.35);
+    border-radius: 10px;
+    padding: 12px 16px;
+    line-height: 1.5;
+}
+.delete-magnet-btn {
+    padding: 10px 18px;
+    border-radius: 8px;
+    border: 1px solid rgba(220, 53, 69, 0.4);
+    background: rgba(220, 53, 69, 0.15);
+    color: #ff6b81;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease, transform 0.2s ease;
+}
+.delete-magnet-btn:hover {
+    background: rgba(220, 53, 69, 0.25);
+    border-color: rgba(220, 53, 69, 0.55);
+    color: #ffc2cb;
+    transform: translateY(-1px);
+}
 
 .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.85); display: flex; justify-content: center; align-items: center; z-index: 1000; backdrop-filter: blur(5px); }
 .modal-content {
@@ -367,13 +512,41 @@ button:disabled {
     line-height: 1.6;
     color: #ced4da;
 }
+.magnet-form { display: flex; flex-direction: column; gap: 12px; margin-top: 20px; }
+.magnet-form input { padding: 10px; border-radius: 8px; border: 1px solid #444; background-color: #2b2b2b; color: #f8f9fa; }
+.magnet-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+.secondary-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 8px;
+    border: 1px solid var(--primary-color);
+    background: transparent;
+    color: var(--primary-color);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease;
+    text-decoration: none;
+}
+.secondary-button:hover { background-color: var(--primary-color); color: var(--secondary-color); transform: translateY(-1px); }
+.secondary-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+.add-library-modal-btn { margin-top: 10px; align-self: flex-start; }
 
-#modal-loser-list { text-align: left; margin-top: 25px; border-top: 1px solid #343a40; padding-top: 20px; }
-#modal-loser-list h3 { margin-bottom: 15px; }
-#modal-loser-list ul { padding-left: 0; list-style: none; display: grid; grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); gap: 15px; }
-.loser-item { display: flex; flex-direction: column; align-items: center; text-align: center; }
-.loser-poster { width: 100%; aspect-ratio: 2 / 3; object-fit: cover; border-radius: 5px; margin-bottom: 5px; box-shadow: 0 2px 5px rgba(0,0,0,0.4); }
-.loser-name { font-size: 12px; color: #adb5bd; }
+#modal-participants { text-align: left; margin-top: 25px; border-top: 1px solid #343a40; padding-top: 20px; }
+#modal-participants h3 { margin-bottom: 15px; }
+.participants-list { padding-left: 0; list-style: none; display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 15px; }
+.participant-item { display: flex; flex-direction: column; align-items: center; text-align: center; background-color: rgba(255, 255, 255, 0.03); padding: 10px; border-radius: 10px; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+.participant-item:hover { transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3); }
+.participant-item.winner { border: 1px solid var(--primary-color); box-shadow: 0 0 12px rgba(255, 193, 7, 0.4); }
+.participant-poster { width: 100%; aspect-ratio: 2 / 3; object-fit: cover; border-radius: 6px; margin-bottom: 8px; box-shadow: 0 2px 5px rgba(0,0,0,0.4); }
+.participant-name { font-size: 13px; color: #f1f3f5; margin-bottom: 4px; }
+.participant-meta { font-size: 11px; color: #adb5bd; }
+.participant-winner-badge { margin-top: 8px; font-size: 11px; font-weight: 700; color: var(--secondary-color); background-color: var(--primary-color); padding: 4px 8px; border-radius: 12px; }
 
 .action-button-tg { display: block; width: 100%; padding: 15px; font-size: 16px; font-weight: 700; text-align: center; text-decoration: none; background-color: #0088cc; color: white; border-radius: 8px; margin-top: 10px; transition: background-color 0.2s, transform 0.2s; }
 .action-button-tg:hover { background-color: #0099e6; transform: translateY(-2px); }
@@ -424,7 +597,22 @@ button:disabled {
 .widget-body {
     padding: 15px;
 }
-#widget-movie-name {
+
+.widget-empty {
+    font-size: 13px;
+    color: #adb5bd;
+    margin: 0 0 10px 0;
+}
+
+.widget-download {
+    margin-bottom: 18px;
+}
+
+.widget-download:last-child {
+    margin-bottom: 0;
+}
+
+.widget-download-title {
     font-size: 13px;
     white-space: nowrap;
     overflow: hidden;
@@ -453,6 +641,14 @@ button:disabled {
     font-size: 12px;
     color: #adb5bd;
     margin-top: 8px;
+}
+
+.widget-stats-bottom {
+    display: flex;
+    justify-content: flex-end;
+    font-size: 11px;
+    color: #868e96;
+    margin-top: 4px;
 }
 
 @media (max-width: 700px) {

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -5,39 +5,252 @@ document.addEventListener('DOMContentLoaded', () => {
     const modalOverlay = document.getElementById('history-modal');
     const closeButton = document.querySelector('.close-button');
     const modalWinnerInfo = document.getElementById('modal-winner-info');
-    const modalLoserListContainer = document.getElementById('modal-loser-list');
-    
-    const widget = document.getElementById('torrent-status-widget');
-    const widgetHeader = widget.querySelector('.widget-header');
-    const widgetMovieName = widget.querySelector('#widget-movie-name');
-    const widgetProgressBar = widget.querySelector('#widget-progress-bar');
-    const widgetProgressText = widget.querySelector('#widget-progress-text');
-    const widgetSpeedText = widget.querySelector('#widget-speed-text');
-    const widgetEtaText = widget.querySelector('#widget-eta-text');
-    // --- НОВОЕ: Элементы для сидов и пиров ---
-    const widgetPeersText = widget.querySelector('#widget-peers-text');
-    let statusPollInterval = null;
+    const modalParticipantsContainer = document.getElementById('modal-participants');
+    const modalParticipantsList = modalParticipantsContainer ? modalParticipantsContainer.querySelector('.participants-list') : null;
 
-    // --- ОБНОВЛЕННАЯ ЛОГИКА ВИДЖЕТА ---
-    const showWidget = (movieName) => {
-        widgetMovieName.textContent = `Загрузка: ${movieName}`;
-        widgetProgressBar.style.width = '0%';
-        widgetProgressText.textContent = '...';
-        widgetSpeedText.textContent = '';
-        widgetEtaText.textContent = '';
-        widgetPeersText.textContent = '';
-        widget.style.display = 'block';
-        widget.classList.remove('minimized');
+    const widget = document.getElementById('torrent-status-widget');
+    const widgetHeader = widget ? widget.querySelector('.widget-header') : null;
+    const widgetDownloadsContainer = widget ? widget.querySelector('#widget-downloads') : null;
+    const widgetEmptyText = widget ? widget.querySelector('.widget-empty') : null;
+
+    const ACTIVE_DOWNLOADS_KEY = 'lotteryActiveDownloads';
+    const pollIntervals = new Map();
+    const activeDownloads = new Map();
+
+    const formatDateTime = (value) => {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        return date.toLocaleString('ru-RU', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
     };
 
-    const updateWidget = (data) => {
-        widgetMovieName.textContent = data.name;
-        widgetProgressText.textContent = `${data.progress}%`;
-        widgetProgressBar.style.width = `${data.progress}%`;
-        widgetSpeedText.textContent = `${data.speed} МБ/с`;
-        widgetEtaText.textContent = data.eta;
-        // --- НОВОЕ: Отображение сидов и пиров ---
-        widgetPeersText.textContent = `Сиды: ${data.seeds} / Пиры: ${data.peers}`;
+    const hydrateDateBadge = (badge) => {
+        if (!badge) return;
+        const formatted = formatDateTime(badge.dataset.date);
+        if (!formatted) {
+            badge.style.display = 'none';
+            return;
+        }
+        badge.innerHTML = `<span class="calendar-icon">&#128197;</span><span>${formatted}</span>`;
+    };
+
+    const hydrateAllDates = () => {
+        document.querySelectorAll('.date-badge').forEach((badge) => hydrateDateBadge(badge));
+    };
+
+    const saveActiveDownloads = () => {
+        if (!widget) return;
+        const payload = Array.from(activeDownloads.values()).map((entry) => ({
+            lotteryId: entry.lotteryId,
+            movieName: entry.movieName,
+            kinopoiskId: entry.kinopoiskId || null,
+        }));
+        localStorage.setItem(ACTIVE_DOWNLOADS_KEY, JSON.stringify(payload));
+    };
+
+    const ensureWidgetState = () => {
+        if (!widget) return;
+        const hasDownloads = activeDownloads.size > 0;
+        widget.style.display = hasDownloads ? 'block' : 'none';
+        if (widgetEmptyText) widgetEmptyText.style.display = hasDownloads ? 'none' : 'block';
+        if (widgetDownloadsContainer) widgetDownloadsContainer.style.display = hasDownloads ? 'block' : 'none';
+        if (hasDownloads) {
+            widget.classList.remove('minimized');
+        }
+    };
+
+    const getOrCreateDownloadElement = (lotteryId) => {
+        if (!widgetDownloadsContainer) return null;
+        let item = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!item) {
+            item = document.createElement('div');
+            item.className = 'widget-download';
+            item.dataset.lotteryId = lotteryId;
+            item.innerHTML = `
+                <h5 class="widget-download-title"></h5>
+                <div class="progress-bar-container">
+                    <div class="progress-bar"></div>
+                </div>
+                <div class="widget-stats">
+                    <span class="progress-text">0%</span>
+                    <span class="speed-text">0.00 МБ/с</span>
+                    <span class="eta-text">--:--</span>
+                </div>
+                <div class="widget-stats-bottom">
+                    <span class="peers-text">Сиды: 0 / Пиры: 0</span>
+                </div>
+            `;
+            widgetDownloadsContainer.appendChild(item);
+        }
+        return item;
+    };
+
+    const registerDownload = (lotteryId, movieName, kinopoiskId, { skipSave = false } = {}) => {
+        if (!lotteryId) return;
+        const existing = activeDownloads.get(lotteryId) || {};
+        const updated = {
+            lotteryId,
+            movieName: movieName || existing.movieName || 'Загрузка...',
+            kinopoiskId: kinopoiskId || existing.kinopoiskId || null,
+        };
+        activeDownloads.set(lotteryId, updated);
+
+        const element = getOrCreateDownloadElement(lotteryId);
+        if (element) {
+            const title = element.querySelector('.widget-download-title');
+            if (title) {
+                title.textContent = `Загрузка: ${updated.movieName}`;
+            }
+        }
+
+        ensureWidgetState();
+        if (!skipSave) saveActiveDownloads();
+        return updated;
+    };
+
+    const removeDownload = (lotteryId) => {
+        if (pollIntervals.has(lotteryId)) {
+            clearInterval(pollIntervals.get(lotteryId));
+            pollIntervals.delete(lotteryId);
+        }
+        if (activeDownloads.has(lotteryId)) {
+            activeDownloads.delete(lotteryId);
+            saveActiveDownloads();
+        }
+        if (widgetDownloadsContainer) {
+            const element = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+            if (element) {
+                element.remove();
+            }
+        }
+        ensureWidgetState();
+    };
+
+    const updateDownloadView = (lotteryId, data) => {
+        if (!widgetDownloadsContainer) return;
+        const element = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!element) return;
+
+        const title = element.querySelector('.widget-download-title');
+        const bar = element.querySelector('.progress-bar');
+        const progressText = element.querySelector('.progress-text');
+        const speedText = element.querySelector('.speed-text');
+        const etaText = element.querySelector('.eta-text');
+        const peersText = element.querySelector('.peers-text');
+
+        if (data.name && title) {
+            title.textContent = `Загрузка: ${data.name}`;
+        }
+
+        if (data.status === 'error') {
+            if (progressText) progressText.textContent = 'Ошибка';
+            if (speedText) speedText.textContent = '-';
+            if (etaText) etaText.textContent = '-';
+            if (peersText) peersText.textContent = data.message || '';
+            if (bar) bar.style.width = '0%';
+            return;
+        }
+
+        if (data.status === 'not_found') {
+            if (progressText) progressText.textContent = 'Ожидание...';
+            if (speedText) speedText.textContent = '0.00 МБ/с';
+            if (etaText) etaText.textContent = '--:--';
+            if (peersText) peersText.textContent = 'Торрент не найден';
+            if (bar) bar.style.width = '0%';
+            return;
+        }
+
+        if (bar) bar.style.width = `${data.progress}%`;
+        if (progressText) progressText.textContent = `${data.progress}%`;
+        if (speedText) speedText.textContent = `${data.speed} МБ/с`;
+        if (etaText) etaText.textContent = data.eta;
+        if (peersText) peersText.textContent = `Сиды: ${data.seeds} / Пиры: ${data.peers}`;
+    };
+
+    const markDownloadCompleted = (lotteryId) => {
+        if (!widgetDownloadsContainer) return;
+        const element = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!element) return;
+
+        const bar = element.querySelector('.progress-bar');
+        const progressText = element.querySelector('.progress-text');
+        const speedText = element.querySelector('.speed-text');
+        const etaText = element.querySelector('.eta-text');
+        const peersText = element.querySelector('.peers-text');
+
+        if (bar) bar.style.width = '100%';
+        if (progressText) progressText.textContent = '100%';
+        if (speedText) speedText.textContent = 'Готово';
+        if (etaText) etaText.textContent = '--';
+        if (peersText) peersText.textContent = 'Раздача';
+
+        setTimeout(() => removeDownload(lotteryId), 5000);
+    };
+
+    const startTorrentStatusPolling = (lotteryId, movieName, kinopoiskId) => {
+        if (!lotteryId) return;
+        registerDownload(lotteryId, movieName, kinopoiskId);
+
+        if (pollIntervals.has(lotteryId)) {
+            clearInterval(pollIntervals.get(lotteryId));
+        }
+
+        const poll = async () => {
+            try {
+                const response = await fetch(`/api/torrent-status/${lotteryId}`);
+                const data = await response.json();
+
+                if (data.status === 'error') {
+                    updateDownloadView(lotteryId, data);
+                    if (pollIntervals.has(lotteryId)) {
+                        clearInterval(pollIntervals.get(lotteryId));
+                        pollIntervals.delete(lotteryId);
+                    }
+                    return;
+                }
+
+                updateDownloadView(lotteryId, data);
+
+                if (data.status && (data.status.includes('seeding') || data.status.includes('completed') || parseFloat(data.progress) >= 100)) {
+                    if (pollIntervals.has(lotteryId)) {
+                        clearInterval(pollIntervals.get(lotteryId));
+                        pollIntervals.delete(lotteryId);
+                    }
+                    markDownloadCompleted(lotteryId);
+                }
+            } catch (error) {
+                console.error('Ошибка при опросе статуса торрента:', error);
+                updateDownloadView(lotteryId, { status: 'error', message: 'Нет связи с qBittorrent' });
+                if (pollIntervals.has(lotteryId)) {
+                    clearInterval(pollIntervals.get(lotteryId));
+                    pollIntervals.delete(lotteryId);
+                }
+            }
+        };
+
+        poll();
+        const intervalId = setInterval(poll, 3000);
+        pollIntervals.set(lotteryId, intervalId);
+    };
+
+    const initializeStoredDownloads = () => {
+        if (!widget) return;
+        try {
+            const stored = JSON.parse(localStorage.getItem(ACTIVE_DOWNLOADS_KEY) || '[]');
+            stored.forEach((entry) => {
+                if (!entry || !entry.lotteryId) return;
+                startTorrentStatusPolling(entry.lotteryId, entry.movieName, entry.kinopoiskId);
+            });
+        } catch (error) {
+            console.warn('Не удалось восстановить активные загрузки:', error);
+            localStorage.removeItem(ACTIVE_DOWNLOADS_KEY);
+        }
     };
 
     if (widgetHeader) {
@@ -46,31 +259,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const startTorrentStatusPolling = (lotteryId, movieName) => {
-        if (statusPollInterval) clearInterval(statusPollInterval);
-        showWidget(movieName);
-        
-        const poll = async () => {
-            try {
-                const response = await fetch(`/api/torrent-status/${lotteryId}`);
-                const data = await response.json();
-
-                if (data.status !== 'not_found' && data.status !== 'error') {
-                    updateWidget(data);
-                    if (data.status.includes('seeding') || data.status.includes('completed') || parseFloat(data.progress) >= 100) {
-                        clearInterval(statusPollInterval);
-                    }
-                }
-            } catch (error) {
-                console.error("Ошибка при опросе статуса торрента:", error);
-                clearInterval(statusPollInterval);
-            }
-        };
-        poll();
-        statusPollInterval = setInterval(poll, 3000);
-    };
-
-    // --- НОВАЯ ЛОГИКА ВЗАИМОДЕЙСТВИЯ ---
+    // --- ЛОГИКА ВЗАИМОДЕЙСТВИЯ С КНОПКАМИ КАРТОЧЕК ---
 
     const handleSearchClick = (movieName, movieYear) => {
         const query = encodeURIComponent(`${movieName} (${movieYear})`);
@@ -79,23 +268,23 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const handleDownloadClick = async (kinopoiskId, movieName, lotteryId) => {
-        showWidget(movieName);
+        registerDownload(lotteryId, movieName, kinopoiskId);
         try {
             const response = await fetch(`/api/start-download/${kinopoiskId}`, { method: 'POST' });
             const data = await response.json();
             if (data.success) {
-                startTorrentStatusPolling(lotteryId, movieName);
+                startTorrentStatusPolling(lotteryId, movieName, kinopoiskId);
             } else {
                 alert(`Ошибка: ${data.message}`);
-                widget.style.display = 'none';
+                removeDownload(lotteryId);
             }
         } catch (error) {
             console.error('Ошибка при запуске скачивания:', error);
             alert('Произошла критическая ошибка.');
-            widget.style.display = 'none';
+            removeDownload(lotteryId);
         }
     };
-    
+
     const handleSaveMagnet = async (kinopoiskId, magnetLink) => {
         try {
             const response = await fetch('/api/movie-magnet', {
@@ -105,9 +294,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             const data = await response.json();
             alert(data.message);
-            if(data.success) {
+            if (data.success) {
                 closeModal();
-                location.reload(); // Перезагружаем страницу для обновления кнопок
+                location.reload();
             }
         } catch (error) {
             console.error('Ошибка при сохранении magnet-ссылки:', error);
@@ -115,7 +304,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    // --- ОБНОВЛЕННАЯ ЛОГИКА УДАЛЕНИЯ ---
     const handleDeleteLottery = async (lotteryId, cardElement) => {
         if (!confirm('Вы уверены, что хотите удалить эту лотерею? Торрент и скачанные файлы также будут удалены из qBittorrent.')) {
             return;
@@ -126,9 +314,7 @@ document.addEventListener('DOMContentLoaded', () => {
             alert(data.message);
             if (data.success) {
                 cardElement.classList.add('is-deleting');
-                // ИЗМЕНЕНИЕ: Скрываем виджет и останавливаем опрос
-                if (statusPollInterval) clearInterval(statusPollInterval);
-                widget.style.display = 'none';
+                removeDownload(lotteryId);
                 setTimeout(() => cardElement.remove(), 500);
             }
         } catch (error) {
@@ -136,18 +322,56 @@ document.addEventListener('DOMContentLoaded', () => {
             alert('Не удалось удалить лотерею.');
         }
     };
-    
-    // --- ОБНОВЛЕННАЯ ЛОГИКА МОДАЛЬНОГО ОКНА ---
+
+    // --- МОДАЛЬНОЕ ОКНО ---
+
+    const renderParticipantsList = (movies, winnerName) => {
+        if (!modalParticipantsContainer || !modalParticipantsList) return;
+        if (!movies || !movies.length) {
+            modalParticipantsContainer.style.display = 'none';
+            modalParticipantsList.innerHTML = '';
+            return;
+        }
+
+        modalParticipantsContainer.style.display = 'block';
+        modalParticipantsList.innerHTML = '';
+
+        movies.forEach((movie) => {
+            const item = document.createElement('li');
+            item.className = 'participant-item';
+            if (movie.name === winnerName) {
+                item.classList.add('winner');
+            }
+
+            item.innerHTML = `
+                <img class="participant-poster" src="${movie.poster || 'https://via.placeholder.com/100x150.png?text=No+Image'}" alt="${movie.name}">
+                <span class="participant-name">${movie.name}</span>
+                <span class="participant-meta">${movie.year || ''}</span>
+                ${movie.name === winnerName ? '<span class="participant-winner-badge">Победитель</span>' : ''}
+            `;
+
+            modalParticipantsList.appendChild(item);
+        });
+    };
+
     const openModal = async (lotteryId) => {
+        if (!modalOverlay) return;
         modalOverlay.style.display = 'flex';
         modalWinnerInfo.innerHTML = '<div class="loader"></div>';
-        modalLoserListContainer.style.display = 'none';
+        if (modalParticipantsContainer) {
+            modalParticipantsContainer.style.display = 'none';
+        }
+        if (modalParticipantsList) {
+            modalParticipantsList.innerHTML = '';
+        }
 
         try {
             const response = await fetch(`/api/result/${lotteryId}`);
             if (!response.ok) throw new Error('Ошибка сети');
             const data = await response.json();
             if (data.error) throw new Error(data.error);
+
+            renderParticipantsList(data.movies || [], data.result ? data.result.name : null);
 
             if (data.result) {
                 renderWinnerCard(data.result);
@@ -170,24 +394,29 @@ document.addEventListener('DOMContentLoaded', () => {
                     </a>
                 `;
 
-                modalWinnerInfo.querySelector('.copy-btn').addEventListener('click', (e) => {
-                    const targetId = e.target.dataset.target;
-                    const input = document.getElementById(targetId);
-                    input.select();
-                    document.execCommand('copy');
-                    e.target.textContent = 'Скопировано!';
-                    setTimeout(() => { e.target.textContent = 'Копировать'; }, 2000);
-                });
+                const copyBtn = modalWinnerInfo.querySelector('.copy-btn');
+                if (copyBtn) {
+                    copyBtn.addEventListener('click', (e) => {
+                        const targetId = e.target.dataset.target;
+                        const input = document.getElementById(targetId);
+                        if (!input) return;
+                        input.select();
+                        document.execCommand('copy');
+                        e.target.textContent = 'Скопировано!';
+                        setTimeout(() => { e.target.textContent = 'Копировать'; }, 2000);
+                    });
+                }
             }
         } catch (error) {
             modalWinnerInfo.innerHTML = `<p class="error-message">Не удалось загрузить детали: ${error.message}</p>`;
         }
     };
-    
+
     const renderWinnerCard = (winner) => {
-        const ratingClass = winner.rating_kp >= 7 ? 'rating-high' : winner.rating_kp >= 5 ? 'rating-medium' : 'rating-low';
-        const ratingBadgeHtml = winner.rating_kp ? `<div class="rating-badge ${ratingClass}">${winner.rating_kp.toFixed(1)}</div>` : '';
-        
+        const ratingValue = typeof winner.rating_kp === 'number' ? winner.rating_kp : 0;
+        const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
+        const ratingBadgeHtml = ratingValue ? `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>` : '';
+
         const magnetFormHtml = `
             <div class="magnet-form">
                 <label for="magnet-input">Magnet-ссылка:</label>
@@ -197,6 +426,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     ${winner.has_magnet ? '<button class="action-button-delete delete-magnet-btn">Удалить ссылку</button>' : ''}
                 </div>
             </div>
+            <button class="secondary-button add-library-modal-btn">Добавить в библиотеку</button>
         `;
 
         modalWinnerInfo.innerHTML = `
@@ -214,32 +444,82 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
         `;
 
-        modalWinnerInfo.querySelector('.save-magnet-btn').addEventListener('click', () => {
-            const input = modalWinnerInfo.querySelector('#magnet-input');
-            handleSaveMagnet(winner.kinopoisk_id, input.value);
-        });
+        const saveBtn = modalWinnerInfo.querySelector('.save-magnet-btn');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', () => {
+                const input = modalWinnerInfo.querySelector('#magnet-input');
+                handleSaveMagnet(winner.kinopoisk_id, input ? input.value : '');
+            });
+        }
 
         const deleteBtn = modalWinnerInfo.querySelector('.delete-magnet-btn');
         if (deleteBtn) {
             deleteBtn.addEventListener('click', () => {
                 if (confirm('Вы уверены, что хотите удалить сохраненную magnet-ссылку?')) {
-                    handleSaveMagnet(winner.kinopoisk_id, ''); // Отправляем пустую строку для удаления
+                    handleSaveMagnet(winner.kinopoisk_id, '');
                 }
+            });
+        }
+
+        const addToLibraryBtn = modalWinnerInfo.querySelector('.add-library-modal-btn');
+        if (addToLibraryBtn) {
+            addToLibraryBtn.addEventListener('click', () => {
+                addMovieToLibrary({
+                    kinopoisk_id: winner.kinopoisk_id || null,
+                    name: winner.name,
+                    year: winner.year,
+                    poster: winner.poster,
+                    description: winner.description,
+                    rating_kp: winner.rating_kp,
+                    genres: winner.genres,
+                    countries: winner.countries,
+                });
             });
         }
     };
 
-    // --- ОБНОВЛЕННЫЙ ОБРАБОТЧИК КЛИКОВ В ГАЛЕРЕЕ ---
+    const buildLibraryPayloadFromCard = (card) => {
+        if (!card) return null;
+        return {
+            kinopoisk_id: card.dataset.kinopoiskId || null,
+            name: card.dataset.movieName || '',
+            year: card.dataset.movieYear || '',
+            poster: card.dataset.moviePoster || '',
+            description: card.dataset.movieDescription || '',
+            rating_kp: card.dataset.movieRating || '',
+            genres: card.dataset.movieGenres || '',
+            countries: card.dataset.movieCountries || '',
+        };
+    };
+
+    const addMovieToLibrary = async (moviePayload) => {
+        if (!moviePayload) return;
+        try {
+            const response = await fetch('/api/library', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ movie: moviePayload }),
+            });
+            const data = await response.json();
+            if (!response.ok || !data.success) {
+                throw new Error(data.message || 'Не удалось добавить фильм.');
+            }
+            alert(data.message || 'Фильм добавлен в библиотеку.');
+        } catch (error) {
+            alert(error.message);
+        }
+    };
+
     if (gallery) {
         gallery.addEventListener('click', (e) => {
             const galleryItem = e.target.closest('.gallery-item');
             if (!galleryItem) return;
 
             const { lotteryId, kinopoiskId, movieName, movieYear } = galleryItem.dataset;
-
             const isDownloadButton = e.target.classList.contains('download-button');
             const isSearchButton = e.target.classList.contains('search-button');
             const isDeleteButton = e.target.classList.contains('delete-button');
+            const isLibraryButton = e.target.classList.contains('library-button');
 
             e.stopPropagation();
 
@@ -249,13 +529,111 @@ document.addEventListener('DOMContentLoaded', () => {
                 handleSearchClick(movieName, movieYear);
             } else if (isDeleteButton) {
                 handleDeleteLottery(lotteryId, galleryItem);
+            } else if (isLibraryButton) {
+                addMovieToLibrary(buildLibraryPayloadFromCard(galleryItem));
             } else {
                 openModal(lotteryId);
             }
         });
     }
 
-    const closeModal = () => { if(modalOverlay) modalOverlay.style.display = 'none'; };
+    const closeModal = () => {
+        if (modalOverlay) {
+            modalOverlay.style.display = 'none';
+        }
+    };
+
     if (closeButton) closeButton.addEventListener('click', closeModal);
-    if (modalOverlay) modalOverlay.addEventListener('click', (e) => { if (e.target === modalOverlay) closeModal(); });
+    if (modalOverlay) {
+        modalOverlay.addEventListener('click', (e) => {
+            if (e.target === modalOverlay) closeModal();
+        });
+    }
+
+    // --- АВТОМАТИЧЕСКОЕ ОБНОВЛЕНИЕ ОЖИДАЮЩИХ ЛОТЕРЕЙ ---
+
+    const waitingCards = new Map();
+    let waitingIntervalId = null;
+    const collectWaitingCards = () => {
+        document.querySelectorAll('.waiting-card').forEach((card) => {
+            const lotteryId = card.dataset.lotteryId;
+            if (lotteryId) {
+                waitingCards.set(lotteryId, card);
+            }
+        });
+    };
+
+    const createCompletedCard = (lotteryId, winner, createdAt) => {
+        const item = document.createElement('div');
+        item.className = 'gallery-item';
+        item.dataset.lotteryId = lotteryId;
+        item.dataset.kinopoiskId = winner.kinopoisk_id || '';
+        item.dataset.movieName = winner.name || '';
+        item.dataset.movieYear = winner.year || '';
+        item.dataset.moviePoster = winner.poster || '';
+        item.dataset.movieDescription = winner.description || '';
+        item.dataset.movieRating = winner.rating_kp != null ? winner.rating_kp : '';
+        item.dataset.movieGenres = winner.genres || '';
+        item.dataset.movieCountries = winner.countries || '';
+
+        const actionButton = winner.has_magnet
+            ? '<button class="action-button download-button" title="Скачать фильм">&#x2913;</button>'
+            : '<button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>';
+
+        item.innerHTML = `
+            <div class="action-buttons">
+                ${actionButton}
+                <button class="action-button library-button" title="Добавить в библиотеку">&#128218;</button>
+                <button class="action-button-delete delete-button" title="Удалить лотерею">&times;</button>
+            </div>
+            <div class="date-badge" data-date="${createdAt}"></div>
+            <img src="${winner.poster || 'https://via.placeholder.com/200x300.png?text=No+Image'}" alt="${winner.name}">
+        `;
+
+        hydrateDateBadge(item.querySelector('.date-badge'));
+
+        return item;
+    };
+
+    const pollWaitingCards = async () => {
+        if (!waitingCards.size) {
+            if (waitingIntervalId) {
+                clearInterval(waitingIntervalId);
+                waitingIntervalId = null;
+            }
+            return;
+        }
+
+        const checkCard = async (lotteryId, cardElement) => {
+            try {
+                const response = await fetch(`/api/result/${lotteryId}`);
+                if (!response.ok) return;
+                const data = await response.json();
+                if (data.result) {
+                    const newCard = createCompletedCard(lotteryId, data.result, data.createdAt);
+                    cardElement.replaceWith(newCard);
+                    waitingCards.delete(lotteryId);
+                }
+            } catch (error) {
+                console.error('Не удалось обновить лотерею', lotteryId, error);
+            }
+        };
+
+        await Promise.all(Array.from(waitingCards.entries()).map(([lotteryId, card]) => checkCard(lotteryId, card)));
+
+        if (!waitingCards.size && waitingIntervalId) {
+            clearInterval(waitingIntervalId);
+            waitingIntervalId = null;
+        }
+    };
+
+    collectWaitingCards();
+    if (waitingCards.size) {
+        pollWaitingCards();
+        waitingIntervalId = setInterval(pollWaitingCards, 5000);
+    }
+
+    initializeStoredDownloads();
+    ensureWidgetState();
+    hydrateAllDates();
 });

--- a/static/js/library.js
+++ b/static/js/library.js
@@ -1,0 +1,398 @@
+// static/js/library.js
+
+document.addEventListener('DOMContentLoaded', () => {
+    const grid = document.querySelector('.library-gallery');
+    if (!grid) return;
+
+    const modal = document.getElementById('library-modal');
+    const modalBody = modal ? document.getElementById('library-modal-body') : null;
+    const closeButton = modal ? modal.querySelector('.close-button') : null;
+    const placeholderPoster = 'https://via.placeholder.com/200x300.png?text=No+Image';
+
+    const setFeedback = (element, message, type = '') => {
+        if (!element) return;
+        element.textContent = message;
+        element.classList.remove('is-error', 'is-success');
+        if (type === 'error') {
+            element.classList.add('is-error');
+        } else if (type === 'success') {
+            element.classList.add('is-success');
+        }
+    };
+
+    const updateActionButton = (card) => {
+        if (!card) return;
+        const primaryBtn = card.querySelector('.library-primary-action');
+        if (!primaryBtn) return;
+
+        const hasMagnet = card.dataset.hasMagnet === 'true';
+        primaryBtn.innerHTML = hasMagnet ? '&#x2913;' : '&#x1F50D;';
+        primaryBtn.title = hasMagnet ? 'Скачать фильм' : 'Искать торрент';
+        primaryBtn.classList.toggle('download-button', hasMagnet);
+        primaryBtn.classList.toggle('search-button', !hasMagnet);
+        card.classList.toggle('has-magnet', hasMagnet);
+    };
+
+    const closeModal = () => {
+        if (!modal) return;
+        modal.style.display = 'none';
+        if (modalBody) {
+            modalBody.innerHTML = '';
+        }
+        if (modal.dataset) {
+            delete modal.dataset.activeId;
+        }
+        document.body.classList.remove('no-scroll');
+    };
+
+    const handleSearch = (card) => {
+        if (!card) return;
+        const name = card.dataset.movieName || '';
+        const year = card.dataset.movieYear || '';
+        const query = year ? `${name} (${year})` : name;
+        if (!query.trim()) return;
+        const url = `https://rutracker.org/forum/tracker.php?nm=${encodeURIComponent(query)}`;
+        window.open(url, '_blank');
+    };
+
+    const handleDownload = async (card, triggerButton) => {
+        if (!card) return;
+        const kinopoiskId = card.dataset.kinopoiskId;
+        if (!kinopoiskId) {
+            alert('Для этого фильма нет сохранённого идентификатора Кинопоиска.');
+            return;
+        }
+
+        if (triggerButton) {
+            triggerButton.disabled = true;
+            triggerButton.classList.add('is-busy');
+        }
+
+        try {
+            const response = await fetch(`/api/start-download/${kinopoiskId}`, { method: 'POST' });
+            const data = await response.json();
+            if (!response.ok || !data.success) {
+                throw new Error(data.message || 'Не удалось запустить скачивание.');
+            }
+            alert(data.message || 'Загрузка началась!');
+        } catch (error) {
+            console.error('Ошибка при запуске скачивания:', error);
+            alert(error.message || 'Не удалось запустить скачивание.');
+        } finally {
+            if (triggerButton) {
+                triggerButton.disabled = false;
+                triggerButton.classList.remove('is-busy');
+            }
+        }
+    };
+
+    const handleRemoveCard = async (card) => {
+        if (!card) return;
+        const movieId = card.dataset.libraryId;
+        if (!movieId) return;
+
+        if (!confirm('Удалить фильм из библиотеки?')) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`/api/library/${movieId}`, { method: 'DELETE' });
+            const data = await response.json();
+            if (!response.ok || !data.success) {
+                throw new Error(data.message || 'Не удалось удалить фильм.');
+            }
+
+            card.classList.add('is-deleting');
+            if (modal && modal.dataset.activeId === movieId) {
+                closeModal();
+            }
+
+            setTimeout(() => {
+                card.remove();
+                if (!grid.querySelector('.gallery-item')) {
+                    const emptyMessage = document.createElement('p');
+                    emptyMessage.className = 'no-history';
+                    emptyMessage.textContent = 'В библиотеке пока нет фильмов.';
+                    grid.appendChild(emptyMessage);
+                }
+            }, 220);
+        } catch (error) {
+            console.error('Ошибка при удалении фильма из библиотеки:', error);
+            alert(error.message || 'Не удалось удалить фильм из библиотеки.');
+        }
+    };
+
+    const handleMagnetSave = async (card, controls) => {
+        const { input, feedback, saveBtn, deleteBtn } = controls;
+        if (!card || !input) return;
+        const kinopoiskId = card.dataset.kinopoiskId;
+        if (!kinopoiskId) {
+            setFeedback(feedback, 'Для этого фильма недоступно сохранение magnet-ссылки.', 'error');
+            return;
+        }
+
+        const magnetLink = (input.value || '').trim();
+        if (!magnetLink) {
+            setFeedback(feedback, 'Введите magnet-ссылку или используйте удаление.', 'error');
+            return;
+        }
+
+        try {
+            if (saveBtn) {
+                saveBtn.disabled = true;
+                saveBtn.textContent = 'Сохранение...';
+            }
+            setFeedback(feedback, '', '');
+            const response = await fetch('/api/movie-magnet', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    kinopoisk_id: Number(kinopoiskId),
+                    magnet_link: magnetLink,
+                }),
+            });
+            const data = await response.json();
+            if (!response.ok || !data.success) {
+                throw new Error(data.message || 'Не удалось сохранить ссылку.');
+            }
+
+            card.dataset.hasMagnet = data.has_magnet ? 'true' : 'false';
+            card.dataset.magnetLink = data.magnet_link || magnetLink;
+            input.value = data.magnet_link || magnetLink;
+            updateActionButton(card);
+            if (deleteBtn) {
+                deleteBtn.style.display = data.has_magnet ? '' : 'none';
+            }
+            setFeedback(feedback, data.message || 'Magnet-ссылка сохранена.', 'success');
+        } catch (error) {
+            console.error('Ошибка при сохранении magnet-ссылки:', error);
+            setFeedback(feedback, error.message || 'Не удалось сохранить ссылку.', 'error');
+        } finally {
+            if (saveBtn) {
+                saveBtn.disabled = false;
+                saveBtn.textContent = 'Сохранить';
+            }
+        }
+    };
+
+    const handleMagnetDelete = async (card, controls) => {
+        const { input, feedback, deleteBtn } = controls;
+        if (!card) return;
+        const kinopoiskId = card.dataset.kinopoiskId;
+        if (!kinopoiskId) {
+            setFeedback(feedback, 'Для этого фильма недоступно удаление magnet-ссылки.', 'error');
+            return;
+        }
+
+        if (!confirm('Удалить сохранённую magnet-ссылку?')) {
+            return;
+        }
+
+        try {
+            if (deleteBtn) {
+                deleteBtn.disabled = true;
+            }
+            setFeedback(feedback, '', '');
+            const response = await fetch('/api/movie-magnet', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    kinopoisk_id: Number(kinopoiskId),
+                    magnet_link: '',
+                }),
+            });
+            const data = await response.json();
+            if (!response.ok || !data.success) {
+                throw new Error(data.message || 'Не удалось удалить ссылку.');
+            }
+
+            card.dataset.hasMagnet = 'false';
+            card.dataset.magnetLink = '';
+            if (input) {
+                input.value = '';
+                input.focus();
+            }
+            updateActionButton(card);
+            if (deleteBtn) {
+                deleteBtn.disabled = false;
+                deleteBtn.style.display = 'none';
+            }
+            setFeedback(feedback, data.message || 'Magnet-ссылка удалена.', 'success');
+        } catch (error) {
+            console.error('Ошибка при удалении magnet-ссылки:', error);
+            setFeedback(feedback, error.message || 'Не удалось удалить ссылку.', 'error');
+            if (deleteBtn) {
+                deleteBtn.disabled = false;
+            }
+        }
+    };
+
+    const openModal = (card) => {
+        if (!modal || !modalBody || !card) return;
+        modalBody.innerHTML = '';
+        modal.dataset.activeId = card.dataset.libraryId || '';
+        modal.style.display = 'flex';
+        document.body.classList.add('no-scroll');
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'winner-card';
+
+        const posterWrapper = document.createElement('div');
+        posterWrapper.className = 'winner-poster';
+        const posterImage = document.createElement('img');
+        posterImage.src = card.dataset.moviePoster || placeholderPoster;
+        posterImage.alt = `Постер ${card.dataset.movieName || ''}`;
+        posterWrapper.appendChild(posterImage);
+
+        const ratingValue = parseFloat(card.dataset.movieRating || '');
+        if (!Number.isNaN(ratingValue) && ratingValue > 0) {
+            const ratingBadge = document.createElement('div');
+            let ratingClass = 'rating-low';
+            if (ratingValue >= 7) ratingClass = 'rating-high';
+            else if (ratingValue >= 5) ratingClass = 'rating-medium';
+            ratingBadge.className = `rating-badge ${ratingClass}`;
+            ratingBadge.textContent = ratingValue.toFixed(1);
+            posterWrapper.appendChild(ratingBadge);
+        }
+
+        const details = document.createElement('div');
+        details.className = 'winner-details';
+
+        const titleEl = document.createElement('h2');
+        const titleName = card.dataset.movieName || 'Неизвестный фильм';
+        const titleYear = card.dataset.movieYear || '';
+        titleEl.textContent = titleYear ? `${titleName} (${titleYear})` : titleName;
+        details.appendChild(titleEl);
+
+        const metaParts = [];
+        if (card.dataset.movieGenres) metaParts.push(card.dataset.movieGenres);
+        if (card.dataset.movieCountries) metaParts.push(card.dataset.movieCountries);
+        if (metaParts.length) {
+            const metaEl = document.createElement('p');
+            metaEl.className = 'meta-info';
+            metaEl.textContent = metaParts.join(' / ');
+            details.appendChild(metaEl);
+        }
+
+        const descriptionEl = document.createElement('p');
+        descriptionEl.className = 'description';
+        descriptionEl.textContent = card.dataset.movieDescription || 'Описание отсутствует.';
+        details.appendChild(descriptionEl);
+
+        const kinopoiskId = card.dataset.kinopoiskId;
+        if (kinopoiskId) {
+            const magnetForm = document.createElement('div');
+            magnetForm.className = 'magnet-form';
+
+            const label = document.createElement('label');
+            label.setAttribute('for', 'library-magnet-input');
+            label.textContent = 'Magnet-ссылка:';
+            magnetForm.appendChild(label);
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.id = 'library-magnet-input';
+            input.value = card.dataset.magnetLink || '';
+            input.placeholder = 'Вставьте magnet-ссылку...';
+            magnetForm.appendChild(input);
+
+            const actions = document.createElement('div');
+            actions.className = 'magnet-actions';
+
+            const saveBtn = document.createElement('button');
+            saveBtn.type = 'button';
+            saveBtn.className = 'secondary-button save-magnet-btn';
+            saveBtn.textContent = 'Сохранить';
+            actions.appendChild(saveBtn);
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.type = 'button';
+            deleteBtn.className = 'delete-magnet-btn';
+            deleteBtn.textContent = 'Удалить ссылку';
+            if (card.dataset.hasMagnet !== 'true') {
+                deleteBtn.style.display = 'none';
+            }
+            actions.appendChild(deleteBtn);
+
+            magnetForm.appendChild(actions);
+
+            const feedback = document.createElement('p');
+            feedback.className = 'magnet-feedback';
+            magnetForm.appendChild(feedback);
+
+            details.appendChild(magnetForm);
+
+            const controls = { input, feedback, saveBtn, deleteBtn };
+
+            saveBtn.addEventListener('click', () => handleMagnetSave(card, controls));
+            deleteBtn.addEventListener('click', () => handleMagnetDelete(card, controls));
+            input.addEventListener('keydown', (evt) => {
+                if (evt.key === 'Enter') {
+                    evt.preventDefault();
+                    handleMagnetSave(card, controls);
+                }
+            });
+
+            setTimeout(() => input.focus(), 120);
+        } else {
+            const warning = document.createElement('p');
+            warning.className = 'magnet-unavailable';
+            warning.textContent = 'Для этого фильма не удалось определить ID на Кинопоиске, поэтому magnet-ссылку сохранить нельзя.';
+            details.appendChild(warning);
+        }
+
+        wrapper.appendChild(posterWrapper);
+        wrapper.appendChild(details);
+        modalBody.appendChild(wrapper);
+    };
+
+    grid.querySelectorAll('.gallery-item').forEach((card) => updateActionButton(card));
+
+    grid.addEventListener('click', (event) => {
+        const removeBtn = event.target.closest('.library-remove-btn');
+        if (removeBtn) {
+            event.preventDefault();
+            event.stopPropagation();
+            const card = removeBtn.closest('.gallery-item');
+            handleRemoveCard(card);
+            return;
+        }
+
+        const primaryBtn = event.target.closest('.library-primary-action');
+        if (primaryBtn) {
+            event.preventDefault();
+            event.stopPropagation();
+            const card = primaryBtn.closest('.gallery-item');
+            if (!card) return;
+            if (card.dataset.hasMagnet === 'true') {
+                handleDownload(card, primaryBtn);
+            } else {
+                handleSearch(card);
+            }
+            return;
+        }
+
+        const card = event.target.closest('.gallery-item');
+        if (!card) return;
+        event.preventDefault();
+        openModal(card);
+    });
+
+    if (closeButton) {
+        closeButton.addEventListener('click', closeModal);
+    }
+
+    if (modal) {
+        modal.addEventListener('click', (event) => {
+            if (event.target === modal) {
+                closeModal();
+            }
+        });
+    }
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && modal && modal.style.display === 'flex') {
+            closeModal();
+        }
+    });
+});

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -37,17 +37,56 @@ document.addEventListener('DOMContentLoaded', () => {
                     <h4>${movie.name}</h4>
                     <p>${movie.year}</p>
                 </div>
+                <div class="movie-card-actions">
+                    <button class="secondary-button library-add-btn" data-index="${index}">Добавить в библиотеку</button>
+                </div>
                 <button class="remove-btn" data-index="${index}">&times;</button>
             `;
             movieListDiv.appendChild(movieCard);
         });
-        
+
         document.querySelectorAll('.remove-btn').forEach(button => {
             button.addEventListener('click', (e) => {
                 const indexToRemove = parseInt(e.target.dataset.index, 10);
                 movies.splice(indexToRemove, 1);
                 renderMovieList();
                 updateCreateButtonState();
+            });
+        });
+
+        document.querySelectorAll('.library-add-btn').forEach(button => {
+            button.addEventListener('click', async (e) => {
+                const indexToAdd = parseInt(e.target.dataset.index, 10);
+                const movieToAdd = movies[indexToAdd];
+                if (!movieToAdd) return;
+
+                const originalText = e.target.textContent;
+                e.target.disabled = true;
+                e.target.textContent = 'Добавление...';
+
+                try {
+                    const response = await fetch('/api/library', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ movie: movieToAdd })
+                    });
+                    const data = await response.json();
+                    if (!response.ok || !data.success) {
+                        throw new Error(data.message || 'Не удалось добавить фильм.');
+                    }
+                    alert(data.message || 'Фильм добавлен в библиотеку.');
+                    e.target.textContent = 'Добавлено!';
+                } catch (error) {
+                    alert(error.message);
+                    e.target.textContent = originalText;
+                    e.target.disabled = false;
+                    return;
+                }
+
+                setTimeout(() => {
+                    e.target.textContent = originalText;
+                    e.target.disabled = false;
+                }, 2000);
             });
         });
     };

--- a/templates/history.html
+++ b/templates/history.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Кино-лотерея: Галерея результатов</title>
+    <title>Кино-лотерея: История лотерей</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -14,8 +14,11 @@
     <div class="background-rotator"></div>
 
     <header class="gallery-header">
-        <h1>Галерея Лотерей</h1>
-        <a href="{{ url_for('index') }}" class="nav-button">&larr; Вернуться к созданию</a>
+        <h1>История лотерей</h1>
+        <div class="gallery-actions">
+            <a href="{{ url_for('index') }}" class="nav-button">&larr; Вернуться к созданию</a>
+            <a href="{{ url_for('library') }}" class="nav-button">Библиотека</a>
+        </div>
     </header>
 
     <div class="history-gallery">
@@ -27,11 +30,16 @@
                 {# ИЗМЕНЕНИЕ: Теперь мы берем информацию из словаря 'identifiers' #}
                 {% set has_identifier = winner_movie and winner_movie.kinopoisk_id in identifiers and identifiers[winner_movie.kinopoisk_id] is not none %}
 
-                <div class="gallery-item" 
-                     data-lottery-id="{{ lottery.id }}" 
-                     data-kinopoisk-id="{{ winner_movie.kinopoisk_id if winner_movie else '' }}" 
+                <div class="gallery-item"
+                     data-lottery-id="{{ lottery.id }}"
+                     data-kinopoisk-id="{{ winner_movie.kinopoisk_id if winner_movie else '' }}"
                      data-movie-name="{{ lottery.result_name }}"
-                     data-movie-year="{{ lottery.result_year }}">
+                     data-movie-year="{{ lottery.result_year }}"
+                     data-movie-poster="{{ (lottery.result_poster or '')|e }}"
+                     data-movie-description="{{ (winner_movie.description|default('', true))|e if winner_movie else '' }}"
+                     data-movie-rating="{{ '%.1f'|format(winner_movie.rating_kp) if winner_movie and winner_movie.rating_kp is not none else '' }}"
+                     data-movie-genres="{{ (winner_movie.genres|default('', true))|e if winner_movie else '' }}"
+                     data-movie-countries="{{ (winner_movie.countries|default('', true))|e if winner_movie else '' }}">
                     <div class="action-buttons">
                         {# ИЗМЕНЕНИЕ: Проверяем наличие идентификатора в словаре #}
                         {% if has_identifier %}
@@ -39,10 +47,11 @@
                         {% else %}
                             <button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>
                         {% endif %}
+                        <button class="action-button library-button" title="Добавить в библиотеку">&#128218;</button>
                         <button class="action-button-delete delete-button" title="Удалить лотерею">&times;</button>
                     </div>
+                    <div class="date-badge" data-date="{{ lottery.created_at.isoformat() }}"></div>
                     <img src="{{ lottery.result_poster or 'https://via.placeholder.com/200x300.png?text=No+Image' }}" alt="{{ lottery.result_name }}">
-                    <div class="date-overlay" data-date="{{ lottery.created_at }}"></div>
                 </div>
             {% else %}
                 {# --- КАРТОЧКА ДЛЯ ОЖИДАЮЩЕЙ ЛОТЕРЕИ --- #}
@@ -54,7 +63,7 @@
                         <div class="loader-small"></div>
                         <span>Ожидает<br>розыгрыша</span>
                     </div>
-                    <div class="date-overlay" data-date="{{ lottery.created_at }}"></div>
+                    <div class="date-badge" data-date="{{ lottery.created_at.isoformat() }}"></div>
                 </div>
             {% endif %}
         {% else %}
@@ -67,9 +76,9 @@
         <div class="modal-content">
             <span class="close-button">&times;</span>
             <div id="modal-winner-info"></div>
-            <div id="modal-loser-list" style="display: none;">
-                 <h3>Проигравшие варианты:</h3>
-                 <ul></ul>
+            <div id="modal-participants" style="display: none;">
+                <h3>Участники лотереи</h3>
+                <ul class="participants-list"></ul>
             </div>
         </div>
     </div>
@@ -81,18 +90,8 @@
             <button id="widget-toggle-btn" class="widget-toggle-btn">&mdash;</button>
         </div>
         <div id="widget-body" class="widget-body">
-            <p id="widget-movie-name">Название фильма...</p>
-            <div class="progress-bar-container">
-                <div id="widget-progress-bar" class="progress-bar"></div>
-            </div>
-            <div class="widget-stats">
-                <span id="widget-progress-text">0%</span>
-                <span id="widget-speed-text">0.00 МБ/с</span>
-                <span id="widget-eta-text">--:--</span>
-            </div>
-             <div class="widget-stats-bottom">
-                <span id="widget-peers-text">Сиды: 0 / Пиры: 0</span>
-            </div>
+            <p class="widget-empty">Активных загрузок нет.</p>
+            <div id="widget-downloads"></div>
         </div>
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,10 @@
         <header>
             <h1>Создай свою Кино-Лотерею</h1>
             <p>Добавь фильмы, которые хочешь разыграть, и тебя перенаправит на страницу ожидания.</p>
-            <a href="{{ url_for('history') }}" class="nav-button">Галерея Истории</a>
+            <div class="nav-links">
+                <a href="{{ url_for('history') }}" class="nav-button">История лотерей</a>
+                <a href="{{ url_for('library') }}" class="nav-button">Библиотека</a>
+            </div>
         </header>
 
         <div class="form-container">

--- a/templates/library.html
+++ b/templates/library.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Кино-лотерея: Библиотека</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body class="gallery-body">
+    <div class="background-rotator"></div>
+
+    <header class="gallery-header">
+        <h1>Библиотека фильмов</h1>
+        <div class="gallery-actions">
+            <a href="{{ url_for('index') }}" class="nav-button">&larr; Вернуться к созданию</a>
+            <a href="{{ url_for('history') }}" class="nav-button">История лотерей</a>
+        </div>
+    </header>
+
+    <div class="history-gallery library-gallery">
+        {% if library_movies %}
+            {% for movie in library_movies %}
+                {% set identifier = movie.identifier %}
+                <div
+                    class="gallery-item library-item{% if identifier %} has-magnet{% endif %}"
+                    data-library-id="{{ movie.id }}"
+                    data-kinopoisk-id="{{ movie.kinopoisk_id or '' }}"
+                    data-movie-name="{{ movie.name }}"
+                    data-movie-year="{{ movie.year or '' }}"
+                    data-movie-poster="{{ movie.poster or '' }}"
+                    data-movie-description="{{ movie.description|default('', true)|e }}"
+                    data-movie-rating="{{ '%.1f'|format(movie.rating_kp) if movie.rating_kp is not none else '' }}"
+                    data-movie-genres="{{ movie.genres|default('', true)|e }}"
+                    data-movie-countries="{{ movie.countries|default('', true)|e }}"
+                    data-magnet-link="{{ identifier.magnet_link|default('', true)|e if identifier else '' }}"
+                    data-has-magnet="{{ 'true' if identifier else 'false' }}"
+                >
+                    <div class="action-buttons">
+                        {% if identifier %}
+                            <button class="library-primary-action download-button" title="Скачать фильм">&#x2913;</button>
+                        {% else %}
+                            <button class="library-primary-action search-button" title="Искать торрент">&#x1F50D;</button>
+                        {% endif %}
+                        <button class="action-button-delete library-remove-btn" title="Удалить из библиотеки">&times;</button>
+                    </div>
+                    <img src="{{ movie.poster or 'https://via.placeholder.com/200x300.png?text=No+Image' }}" alt="{{ movie.name }}">
+                </div>
+            {% endfor %}
+        {% else %}
+            <p class="no-history">В библиотеке пока нет фильмов.</p>
+        {% endif %}
+    </div>
+
+    <div id="library-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <div id="library-modal-body"></div>
+        </div>
+    </div>
+
+    <script src="{{ url_for('static', filename='js/library.js') }}"></script>
+    <script>
+        var backgroundPhotos = {{ background_photos|tojson|safe }};
+    </script>
+    <script src="{{ url_for('static', filename='js/background.js') }}"></script>
+</body>
+</html>

--- a/tests/test_start_download.py
+++ b/tests/test_start_download.py
@@ -28,9 +28,20 @@ class _FakeDownloadClient(_BaseFakeClient):
         _FakeDownloadClient.last_category = category
         return []
 
-    def torrents_add(self, urls=None, category=None, is_sequential=None):
+    def torrents_add(
+        self,
+        urls=None,
+        category=None,
+        is_sequential_download=None,
+        is_first_last_piece_priority=None,
+    ):
         _FakeDownloadClient.added.append(
-            {"urls": urls, "category": category, "is_sequential": is_sequential}
+            {
+                "urls": urls,
+                "category": category,
+                "is_sequential_download": is_sequential_download,
+                "is_first_last_piece_priority": is_first_last_piece_priority,
+            }
         )
 
 
@@ -85,13 +96,11 @@ def test_start_download_calls_search_helper(monkeypatch, app_module):
     assert "началась" in payload["message"]
 
     assert searched_queries == ["Мы, нижеподписавшиеся 1980"]
-    assert _FakeDownloadClient.added == [
-        {
-
-            "category": "lottery-movie1",
-            "is_sequential": "true",
-        }
-    ]
+    assert len(_FakeDownloadClient.added) == 1
+    added_entry = _FakeDownloadClient.added[0]
+    assert added_entry["category"] == "lottery-movie1"
+    assert added_entry["is_sequential_download"] is True
+    assert added_entry["is_first_last_piece_priority"] is True
     assert _FakeDownloadClient.last_category == "lottery-movie1"
 
 


### PR DESCRIPTION
## Summary
- attach `MovieIdentifier` objects to each library entry before rendering so templates can reference them directly
- update the library template to consume the precomputed identifier without relying on advanced Jinja features that caused runtime errors

## Testing
- pytest *(fails: tests/test_torrent_status.py embeds a shell snippet that raises SyntaxError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68cf79fd70e08328bf5ab92a1da86746