### PR TITLE
Fix library page template and interactions

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -358,6 +358,31 @@ button:disabled {
     position: relative;
     animation: zoomIn 0.3s ease-out;
 }
+.library-modal-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 20px;
+}
+
+.danger-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 8px;
+    border: none;
+    background-color: var(--danger-color);
+    color: var(--secondary-color);
+    font-weight: 700;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.danger-button:hover {
+    background-color: #b02a37;
+    transform: translateY(-1px);
+}
 .close-button { position: absolute; top: 10px; right: 20px; font-size: 30px; color: #adb5bd; cursor: pointer; transition: color 0.2s; }
 .close-button:hover { color: white; }
 

--- a/static/js/library.js
+++ b/static/js/library.js
@@ -1,7 +1,66 @@
 // static/js/library.js
 
 document.addEventListener('DOMContentLoaded', () => {
+    const gallery = document.querySelector('.library-gallery');
+    const modalOverlay = document.getElementById('library-modal');
+    const modalBody = document.getElementById('library-modal-body');
+    const closeButton = modalOverlay ? modalOverlay.querySelector('.close-button') : null;
+    const emptyMessage = document.querySelector('.library-empty-message');
+    const placeholderPoster = 'https://via.placeholder.com/200x300.png?text=No+Image';
 
+    const formatDateBadges = () => {
+        if (!gallery) return;
+        const formatter = new Intl.DateTimeFormat('ru-RU', {
+            day: '2-digit',
+            month: 'long',
+            year: 'numeric',
+        });
+
+        gallery.querySelectorAll('.date-badge').forEach((badge) => {
+            const iso = badge.dataset.date;
+            if (!iso) return;
+
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+
+            badge.innerHTML = `<span class="calendar-icon">&#x1F4C5;</span>${formatter.format(date)}`;
+        });
+    };
+
+    const ensureEmptyState = () => {
+        if (!emptyMessage) return;
+        const hasItems = gallery && gallery.querySelector('.gallery-item');
+        emptyMessage.style.display = hasItems ? 'none' : 'block';
+    };
+
+    const closeModal = () => {
+        if (!modalOverlay) return;
+        modalOverlay.style.display = 'none';
+        document.body.classList.remove('no-scroll');
+    };
+
+    const handleSearch = (name, year) => {
+        if (!name) return;
+        const parts = [name.trim()];
+        if (year && year.trim()) {
+            parts.push(`(${year.trim()})`);
+        }
+        const query = encodeURIComponent(parts.join(' '));
+        window.open(`https://rutracker.org/forum/tracker.php?nm=${query}`, '_blank');
+    };
+
+    const removeCardFromDom = (card) => {
+        if (!card) return;
+        card.classList.add('is-deleting');
+        setTimeout(() => {
+            card.remove();
+            ensureEmptyState();
+        }, 300);
+    };
+
+    const handleDelete = async (card) => {
+        if (!card) return;
+        const movieId = card.dataset.movieId;
         if (!movieId) return;
 
         if (!confirm('Удалить фильм из библиотеки?')) {
@@ -15,6 +74,97 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(data.message || 'Не удалось удалить фильм.');
             }
 
+            closeModal();
+            removeCardFromDom(card);
+        } catch (error) {
+            alert(error.message);
         }
-    });
+    };
+
+    const renderModal = (card) => {
+        if (!modalOverlay || !modalBody || !card) return;
+        const {
+            movieName = 'Неизвестный фильм',
+            movieYear = '',
+            moviePoster = '',
+            movieDescription = '',
+            movieGenres = '',
+            movieCountries = '',
+            movieRating = '',
+        } = card.dataset;
+
+        const ratingValue = parseFloat(movieRating);
+        let ratingBadge = '';
+        if (!Number.isNaN(ratingValue)) {
+            const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
+            ratingBadge = `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>`;
+        }
+
+        modalBody.innerHTML = `
+            <div class="winner-card">
+                <div class="winner-poster">
+                    <img src="${moviePoster || placeholderPoster}" alt="Постер ${movieName}">
+                    ${ratingBadge}
+                </div>
+                <div class="winner-details">
+                    <h2>${movieName}${movieYear ? ` (${movieYear})` : ''}</h2>
+                    <p class="meta-info">${movieGenres || 'н/д'} / ${movieCountries || 'н/д'}</p>
+                    <p class="description">${movieDescription || 'Описание отсутствует.'}</p>
+                    <div class="library-modal-actions">
+                        <button class="secondary-button modal-search-btn">Искать торрент</button>
+                        <button class="danger-button modal-delete-btn">Удалить из библиотеки</button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        const searchBtn = modalBody.querySelector('.modal-search-btn');
+        if (searchBtn) {
+            searchBtn.addEventListener('click', () => handleSearch(movieName, movieYear));
+        }
+
+        const deleteBtn = modalBody.querySelector('.modal-delete-btn');
+        if (deleteBtn) {
+            deleteBtn.addEventListener('click', () => handleDelete(card));
+        }
+
+        modalOverlay.style.display = 'flex';
+        document.body.classList.add('no-scroll');
+    };
+
+    if (gallery) {
+        gallery.addEventListener('click', (event) => {
+            const card = event.target.closest('.gallery-item');
+            if (!card) return;
+
+            if (event.target.classList.contains('search-button')) {
+                event.stopPropagation();
+                handleSearch(card.dataset.movieName, card.dataset.movieYear);
+                return;
+            }
+
+            if (event.target.classList.contains('delete-button')) {
+                event.stopPropagation();
+                handleDelete(card);
+                return;
+            }
+
+            renderModal(card);
+        });
+    }
+
+    if (closeButton) {
+        closeButton.addEventListener('click', closeModal);
+    }
+
+    if (modalOverlay) {
+        modalOverlay.addEventListener('click', (event) => {
+            if (event.target === modalOverlay) {
+                closeModal();
+            }
+        });
+    }
+
+    formatDateBadges();
+    ensureEmptyState();
 });

--- a/templates/library.html
+++ b/templates/library.html
@@ -20,14 +20,40 @@
         </div>
     </header>
 
-
+    <div class="history-gallery library-gallery">
+        {% if library_movies %}
+            {% for movie in library_movies %}
+                <div
+                    class="gallery-item library-card"
+                    data-movie-id="{{ movie.id }}"
+                    data-movie-name="{{ movie.name|e }}"
+                    data-movie-year="{{ movie.year or '' }}"
+                    data-movie-poster="{{ (movie.poster or '')|e }}"
+                    data-movie-description="{{ (movie.description|default('', true)|replace('\n', ' '))|e }}"
+                    data-movie-rating="{{ '%.1f'|format(movie.rating_kp) if movie.rating_kp is not none else '' }}"
+                    data-movie-genres="{{ (movie.genres|default('', true))|e }}"
+                    data-movie-countries="{{ (movie.countries|default('', true))|e }}"
+                    data-added-at="{{ movie.added_at.isoformat() }}"
+                >
+                    <div class="action-buttons">
+                        <button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>
+                        <button class="action-button-delete delete-button" title="Удалить из библиотеки">&times;</button>
+                    </div>
+                    <div class="date-badge" data-date="{{ movie.added_at.isoformat() }}"></div>
+                    <img src="{{ movie.poster or 'https://via.placeholder.com/200x300.png?text=No+Image' }}" alt="{{ movie.name|e }}">
                 </div>
             {% endfor %}
-        {% else %}
-            <p class="no-history">В библиотеке пока нет фильмов.</p>
         {% endif %}
     </div>
 
+    <p class="no-history library-empty-message"{% if library_movies %} style="display: none;"{% endif %}>В библиотеке пока нет фильмов.</p>
+
+    <div id="library-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <div id="library-modal-body"></div>
+        </div>
+    </div>
 
     <script src="{{ url_for('static', filename='js/library.js') }}"></script>
     <script>


### PR DESCRIPTION
## Summary
- restore the full library page template so saved films render correctly with metadata and modal support
- rebuild the library page script to handle modal display, deletions, torrent search shortcuts, and empty state updates
- add styles for the library modal action buttons to match the existing gallery look and feel

## Testing
- pytest *(fails: SyntaxError in tests/test_torrent_status.py because the test file in the repository contains leftover patch text)*

------
https://chatgpt.com/codex/tasks/task_e_68cf94fcedf08328939e1ad217817d50