### PR TITLE
Restore history modal interactions and sharing

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -358,6 +358,31 @@ button:disabled {
     position: relative;
     animation: zoomIn 0.3s ease-out;
 }
+.library-modal-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 20px;
+}
+
+.danger-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 8px;
+    border: none;
+    background-color: var(--danger-color);
+    color: var(--secondary-color);
+    font-weight: 700;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.danger-button:hover {
+    background-color: #b02a37;
+    transform: translateY(-1px);
+}
 .close-button { position: absolute; top: 10px; right: 20px; font-size: 30px; color: #adb5bd; cursor: pointer; transition: color 0.2s; }
 .close-button:hover { color: white; }
 

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -3,20 +3,145 @@
 document.addEventListener('DOMContentLoaded', () => {
     const gallery = document.querySelector('.history-gallery');
     const modalOverlay = document.getElementById('history-modal');
-    const closeButton = document.querySelector('.close-button');
+    const closeButton = modalOverlay ? modalOverlay.querySelector('.close-button') : null;
     const modalWinnerInfo = document.getElementById('modal-winner-info');
     const modalParticipantsContainer = document.getElementById('modal-participants');
     const modalParticipantsList = modalParticipantsContainer ? modalParticipantsContainer.querySelector('.participants-list') : null;
 
     const widget = document.getElementById('torrent-status-widget');
     const widgetHeader = widget ? widget.querySelector('.widget-header') : null;
+    const widgetToggleBtn = widget ? widget.querySelector('#widget-toggle-btn') : null;
     const widgetDownloadsContainer = widget ? widget.querySelector('#widget-downloads') : null;
     const widgetEmptyText = widget ? widget.querySelector('.widget-empty') : null;
 
     const ACTIVE_DOWNLOADS_KEY = 'lotteryActiveDownloads';
+    const placeholderPoster = 'https://via.placeholder.com/200x300.png?text=No+Image';
+
     const pollIntervals = new Map();
     const activeDownloads = new Map();
 
+    let currentModalLotteryId = null;
+
+    const escapeHtml = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    };
+
+    const escapeAttr = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;');
+    };
+
+    const safeJsonParse = (value) => {
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const saveActiveDownloads = () => {
+        if (!widget) return;
+        try {
+            const payload = Array.from(activeDownloads.values()).map((entry) => ({
+                lotteryId: entry.lotteryId,
+                movieName: entry.movieName,
+                kinopoiskId: entry.kinopoiskId || null,
+            }));
+            localStorage.setItem(ACTIVE_DOWNLOADS_KEY, JSON.stringify(payload));
+        } catch (error) {
+            console.warn('Не удалось сохранить активные загрузки:', error);
+        }
+    };
+
+    const loadStoredDownloads = () => {
+        if (!widget) return [];
+        try {
+            const raw = localStorage.getItem(ACTIVE_DOWNLOADS_KEY);
+            if (!raw) return [];
+            const parsed = safeJsonParse(raw);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+            console.warn('Не удалось восстановить активные загрузки:', error);
+            localStorage.removeItem(ACTIVE_DOWNLOADS_KEY);
+            return [];
+        }
+    };
+
+    const ensureWidgetState = () => {
+        if (!widget) return;
+        const hasDownloads = activeDownloads.size > 0;
+        widget.style.display = hasDownloads ? 'block' : 'none';
+        if (widgetEmptyText) {
+            widgetEmptyText.style.display = hasDownloads ? 'none' : 'block';
+        }
+        if (widgetDownloadsContainer) {
+            widgetDownloadsContainer.style.display = hasDownloads ? 'block' : 'none';
+        }
+        if (hasDownloads) {
+            widget.classList.remove('minimized');
+        }
+    };
+
+    const getOrCreateDownloadElement = (lotteryId) => {
+        if (!widgetDownloadsContainer) return null;
+        let item = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!item) {
+            item = document.createElement('div');
+            item.className = 'widget-download';
+            item.dataset.lotteryId = lotteryId;
+            item.innerHTML = `
+                <h5 class="widget-download-title"></h5>
+                <div class="progress-bar-container">
+                    <div class="progress-bar"></div>
+                </div>
+                <div class="widget-stats">
+                    <span class="progress-text">0%</span>
+                    <span class="speed-text">0.00 МБ/с</span>
+                    <span class="eta-text">--:--</span>
+                </div>
+                <div class="widget-stats-bottom">
+                    <span class="peers-text">Сиды: 0 / Пиры: 0</span>
+                </div>
+            `;
+            widgetDownloadsContainer.appendChild(item);
+        }
+        return item;
+    };
+
+    const registerDownload = (lotteryId, movieName, kinopoiskId, { skipSave = false } = {}) => {
+        if (!widget || !lotteryId) return null;
+        const existing = activeDownloads.get(lotteryId) || {};
+        const updated = {
+            lotteryId,
+            movieName: movieName || existing.movieName || 'Загрузка...',
+            kinopoiskId: kinopoiskId || existing.kinopoiskId || null,
+        };
+        activeDownloads.set(lotteryId, updated);
+
+        const element = getOrCreateDownloadElement(lotteryId);
+        if (element) {
+            const title = element.querySelector('.widget-download-title');
+            if (title) {
+                title.textContent = `Загрузка: ${updated.movieName}`;
+            }
+        }
+
+        ensureWidgetState();
+        if (!skipSave) saveActiveDownloads();
+        return updated;
+    };
 
     const removeDownload = (lotteryId) => {
         if (pollIntervals.has(lotteryId)) {
@@ -70,11 +195,12 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        if (bar) bar.style.width = `${data.progress}%`;
-        if (progressText) progressText.textContent = `${data.progress}%`;
-        if (speedText) speedText.textContent = `${data.speed} МБ/с`;
-        if (etaText) etaText.textContent = data.eta;
-        if (peersText) peersText.textContent = `Сиды: ${data.seeds} / Пиры: ${data.peers}`;
+        const progressValue = Number.parseFloat(data.progress) || 0;
+        if (bar) bar.style.width = `${Math.min(100, Math.max(0, progressValue))}%`;
+        if (progressText) progressText.textContent = `${progressValue.toFixed(0)}%`;
+        if (speedText) speedText.textContent = data.speed ? `${data.speed} МБ/с` : '0.00 МБ/с';
+        if (etaText) etaText.textContent = data.eta || '--:--';
+        if (peersText) peersText.textContent = `Сиды: ${data.seeds ?? 0} / Пиры: ${data.peers ?? 0}`;
     };
 
     const markDownloadCompleted = (lotteryId) => {
@@ -97,9 +223,11 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => removeDownload(lotteryId), 5000);
     };
 
-    const startTorrentStatusPolling = (lotteryId, movieName, kinopoiskId) => {
+    const startTorrentStatusPolling = (lotteryId, movieName, kinopoiskId, { skipRegister = false } = {}) => {
         if (!lotteryId) return;
-        registerDownload(lotteryId, movieName, kinopoiskId);
+        if (!skipRegister) {
+            registerDownload(lotteryId, movieName, kinopoiskId);
+        }
 
         if (pollIntervals.has(lotteryId)) {
             clearInterval(pollIntervals.get(lotteryId));
@@ -108,6 +236,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const poll = async () => {
             try {
                 const response = await fetch(`/api/torrent-status/${lotteryId}`);
+                if (!response.ok) {
+                    throw new Error('Сервер вернул ошибку статуса');
+                }
                 const data = await response.json();
 
                 if (data.status === 'error') {
@@ -115,7 +246,21 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (pollIntervals.has(lotteryId)) {
                         clearInterval(pollIntervals.get(lotteryId));
                         pollIntervals.delete(lotteryId);
+                    }
+                    return;
+                }
 
+                updateDownloadView(lotteryId, data);
+
+                const progressValue = Number.parseFloat(data.progress) || 0;
+                const statusText = (data.status || '').toLowerCase();
+                const isCompleted = progressValue >= 100 || statusText.includes('seeding') || statusText.includes('completed');
+
+                if (isCompleted) {
+                    if (pollIntervals.has(lotteryId)) {
+                        clearInterval(pollIntervals.get(lotteryId));
+                        pollIntervals.delete(lotteryId);
+                    }
                     markDownloadCompleted(lotteryId);
                 }
             } catch (error) {
@@ -131,244 +276,109 @@ document.addEventListener('DOMContentLoaded', () => {
         poll();
         const intervalId = setInterval(poll, 3000);
         pollIntervals.set(lotteryId, intervalId);
-
-    if (widgetHeader) {
-        widgetHeader.addEventListener('click', () => {
-            widget.classList.toggle('minimized');
-        });
-    }
-
-    // --- ЛОГИКА ВЗАИМОДЕЙСТВИЯ С КНОПКАМИ КАРТОЧЕК ---
-
-    const handleSearchClick = (movieName, movieYear) => {
-        const query = encodeURIComponent(`${movieName} (${movieYear})`);
-        const searchUrl = `https://rutracker.org/forum/tracker.php?nm=${query}`;
-        window.open(searchUrl, '_blank');
     };
 
-    const handleDownloadClick = async (kinopoiskId, movieName, lotteryId) => {
-        registerDownload(lotteryId, movieName, kinopoiskId);
-        try {
-            const response = await fetch(`/api/start-download/${kinopoiskId}`, { method: 'POST' });
-            const data = await response.json();
-            if (data.success) {
-                startTorrentStatusPolling(lotteryId, movieName, kinopoiskId);
-            } else {
-                alert(`Ошибка: ${data.message}`);
-                removeDownload(lotteryId);
-            }
-        } catch (error) {
-            console.error('Ошибка при запуске скачивания:', error);
-            alert('Произошла критическая ошибка.');
-            removeDownload(lotteryId);
-        }
-    };
-
-    const handleSaveMagnet = async (kinopoiskId, magnetLink) => {
-        try {
-            const response = await fetch('/api/movie-magnet', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ kinopoisk_id: kinopoiskId, magnet_link: magnetLink })
-            });
-            const data = await response.json();
-            alert(data.message);
-            if (data.success) {
-                closeModal();
-                location.reload();
-            }
-        } catch (error) {
-            console.error('Ошибка при сохранении magnet-ссылки:', error);
-            alert('Произошла критическая ошибка.');
-        }
-    };
-
-    const handleDeleteLottery = async (lotteryId, cardElement) => {
-        if (!confirm('Вы уверены, что хотите удалить эту лотерею? Торрент и скачанные файлы также будут удалены из qBittorrent.')) {
-            return;
-        }
-        try {
-            const response = await fetch(`/delete-lottery/${lotteryId}`, { method: 'POST' });
-            const data = await response.json();
-            alert(data.message);
-            if (data.success) {
-                cardElement.classList.add('is-deleting');
-                removeDownload(lotteryId);
-                setTimeout(() => cardElement.remove(), 500);
-            }
-        } catch (error) {
-            console.error('Ошибка при удалении лотереи:', error);
-            alert('Не удалось удалить лотерею.');
-        }
-    };
-
-    // --- МОДАЛЬНОЕ ОКНО ---
-
-    const renderParticipantsList = (movies, winnerName) => {
-        if (!modalParticipantsContainer || !modalParticipantsList) return;
-        if (!movies || !movies.length) {
-            modalParticipantsContainer.style.display = 'none';
-            modalParticipantsList.innerHTML = '';
-            return;
-        }
-
-        modalParticipantsContainer.style.display = 'block';
-        modalParticipantsList.innerHTML = '';
-
-        movies.forEach((movie) => {
-            const item = document.createElement('li');
-            item.className = 'participant-item';
-            if (movie.name === winnerName) {
-                item.classList.add('winner');
-            }
-
-            item.innerHTML = `
-                <img class="participant-poster" src="${movie.poster || 'https://via.placeholder.com/100x150.png?text=No+Image'}" alt="${movie.name}">
-                <span class="participant-name">${movie.name}</span>
-                <span class="participant-meta">${movie.year || ''}</span>
-                ${movie.name === winnerName ? '<span class="participant-winner-badge">Победитель</span>' : ''}
-            `;
-
-            modalParticipantsList.appendChild(item);
+    const initializeStoredDownloads = () => {
+        if (!widget) return;
+        const stored = loadStoredDownloads();
+        stored.forEach((entry) => {
+            if (!entry || !entry.lotteryId) return;
+            startTorrentStatusPolling(entry.lotteryId, entry.movieName, entry.kinopoiskId);
         });
     };
 
-    const openModal = async (lotteryId) => {
-        if (!modalOverlay) return;
-        modalOverlay.style.display = 'flex';
-        modalWinnerInfo.innerHTML = '<div class="loader"></div>';
-        if (modalParticipantsContainer) {
-            modalParticipantsContainer.style.display = 'none';
-        }
-        if (modalParticipantsList) {
-            modalParticipantsList.innerHTML = '';
+    const formatDateBadges = () => {
+        if (!gallery) return;
+        const formatter = new Intl.DateTimeFormat('ru-RU', {
+            day: '2-digit',
+            month: 'long',
+            year: 'numeric',
+        });
+
+        gallery.querySelectorAll('.date-badge').forEach((badge) => {
+            const iso = badge.dataset.date;
+            if (!iso) return;
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+            badge.innerHTML = `<span class="calendar-icon">&#x1F4C5;</span>${formatter.format(date)}`;
+        });
+    };
+
+    const refreshCardActions = (lotteryId, winner) => {
+        if (!gallery) return;
+        const card = gallery.querySelector(`.gallery-item[data-lottery-id="${lotteryId}"]`);
+        if (!card) return;
+
+        if (winner) {
+            card.dataset.kinopoiskId = winner.kinopoisk_id || '';
+            card.dataset.movieName = winner.name || '';
+            card.dataset.movieYear = winner.year || '';
+            card.dataset.moviePoster = winner.poster || '';
+            card.dataset.movieDescription = winner.description || '';
+            card.dataset.movieRating = winner.rating_kp != null ? winner.rating_kp : '';
+            card.dataset.movieGenres = winner.genres || '';
+            card.dataset.movieCountries = winner.countries || '';
         }
 
+        const buttons = card.querySelector('.action-buttons');
+        if (!buttons) return;
+
+        const existingDownloadBtn = buttons.querySelector('.download-button');
+        const existingSearchBtn = buttons.querySelector('.search-button');
+
+        if (winner && winner.has_magnet) {
+            if (existingSearchBtn) {
+                const downloadBtn = document.createElement('button');
+                downloadBtn.className = 'action-button download-button';
+                downloadBtn.title = 'Скачать фильм';
+                downloadBtn.innerHTML = '&#x2913;';
+                buttons.replaceChild(downloadBtn, existingSearchBtn);
+            } else if (!existingDownloadBtn) {
+                const downloadBtn = document.createElement('button');
+                downloadBtn.className = 'action-button download-button';
+                downloadBtn.title = 'Скачать фильм';
+                downloadBtn.innerHTML = '&#x2913;';
+                buttons.insertBefore(downloadBtn, buttons.firstChild);
+            }
+        } else {
+            if (existingDownloadBtn) {
+                const searchBtn = document.createElement('button');
+                searchBtn.className = 'action-button search-button';
+                searchBtn.title = 'Искать торрент';
+                searchBtn.innerHTML = '&#x1F50D;';
+                buttons.replaceChild(searchBtn, existingDownloadBtn);
+            } else if (!existingSearchBtn) {
+                const searchBtn = document.createElement('button');
+                searchBtn.className = 'action-button search-button';
+                searchBtn.title = 'Искать торрент';
+                searchBtn.innerHTML = '&#x1F50D;';
+                buttons.insertBefore(searchBtn, buttons.firstChild);
+            }
+        }
+    };
+
+    const copyToClipboard = async (value, feedbackTarget) => {
         try {
-            const response = await fetch(`/api/result/${lotteryId}`);
-            if (!response.ok) throw new Error('Ошибка сети');
-            const data = await response.json();
-            if (data.error) throw new Error(data.error);
-
-            renderParticipantsList(data.movies || [], data.result ? data.result.name : null);
-
-            if (data.result) {
-                renderWinnerCard(data.result);
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(value);
             } else {
-                const playUrl = data.play_url;
-                const text = encodeURIComponent('Привет! Предлагаю тебе определить, какой фильм мы посмотрим. Нажми на ссылку и испытай удачу!');
-                const url = encodeURIComponent(playUrl);
-                const telegramHref = `https://t.me/share/url?url=${url}&text=${text}`;
-
-                modalWinnerInfo.innerHTML = `
-                    <h3>Лотерея ожидает розыгрыша</h3>
-                    <p>Поделитесь ссылкой с другом, чтобы он мог выбрать фильм.</p>
-                    <div class="link-box">
-                        <label for="play-link-modal">Ссылка для друга:</label>
-                        <input type="text" id="play-link-modal" value="${playUrl}" readonly>
-                        <button class="copy-btn" data-target="play-link-modal">Копировать</button>
-                    </div>
-                    <a href="${telegramHref}" class="action-button-tg" target="_blank">
-                        Поделиться в Telegram
-                    </a>
-                `;
-
-                const copyBtn = modalWinnerInfo.querySelector('.copy-btn');
-                if (copyBtn) {
-                    copyBtn.addEventListener('click', (e) => {
-                        const targetId = e.target.dataset.target;
-                        const input = document.getElementById(targetId);
-                        if (!input) return;
-                        input.select();
-                        document.execCommand('copy');
-                        e.target.textContent = 'Скопировано!';
-                        setTimeout(() => { e.target.textContent = 'Копировать'; }, 2000);
-                    });
-                }
+                const tempInput = document.createElement('input');
+                tempInput.value = value;
+                document.body.appendChild(tempInput);
+                tempInput.select();
+                document.execCommand('copy');
+                document.body.removeChild(tempInput);
+            }
+            if (feedbackTarget) {
+                const original = feedbackTarget.textContent;
+                feedbackTarget.textContent = 'Скопировано!';
+                setTimeout(() => {
+                    feedbackTarget.textContent = original;
+                }, 2000);
             }
         } catch (error) {
-            modalWinnerInfo.innerHTML = `<p class="error-message">Не удалось загрузить детали: ${error.message}</p>`;
+            console.error('Не удалось скопировать ссылку:', error);
         }
-    };
-
-    const renderWinnerCard = (winner) => {
-        const ratingValue = typeof winner.rating_kp === 'number' ? winner.rating_kp : 0;
-        const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
-        const ratingBadgeHtml = ratingValue ? `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>` : '';
-
-        const magnetFormHtml = `
-            <div class="magnet-form">
-                <label for="magnet-input">Magnet-ссылка:</label>
-                <input type="text" id="magnet-input" value="${winner.magnet_link || ''}" placeholder="Вставьте magnet-ссылку и нажмите Сохранить...">
-                <div class="magnet-actions">
-                    <button class="action-button save-magnet-btn">Сохранить</button>
-                    ${winner.has_magnet ? '<button class="action-button-delete delete-magnet-btn">Удалить ссылку</button>' : ''}
-                </div>
-            </div>
-            <button class="secondary-button add-library-modal-btn">Добавить в библиотеку</button>
-        `;
-
-        modalWinnerInfo.innerHTML = `
-            <div class="winner-card">
-                <div class="winner-poster">
-                    <img src="${winner.poster || ''}" alt="Постер ${winner.name}">
-                    ${ratingBadgeHtml}
-                </div>
-                <div class="winner-details">
-                    <h2>${winner.name} (${winner.year})</h2>
-                    <p class="meta-info">${winner.genres || 'н/д'} / ${winner.countries || 'н/д'}</p>
-                    <p class="description">${winner.description || 'Описание отсутствует.'}</p>
-                    ${magnetFormHtml}
-                </div>
-            </div>
-        `;
-
-        const saveBtn = modalWinnerInfo.querySelector('.save-magnet-btn');
-        if (saveBtn) {
-            saveBtn.addEventListener('click', () => {
-                const input = modalWinnerInfo.querySelector('#magnet-input');
-                handleSaveMagnet(winner.kinopoisk_id, input ? input.value : '');
-            });
-        }
-
-        const deleteBtn = modalWinnerInfo.querySelector('.delete-magnet-btn');
-        if (deleteBtn) {
-            deleteBtn.addEventListener('click', () => {
-                if (confirm('Вы уверены, что хотите удалить сохраненную magnet-ссылку?')) {
-                    handleSaveMagnet(winner.kinopoisk_id, '');
-                }
-            });
-        }
-
-        const addToLibraryBtn = modalWinnerInfo.querySelector('.add-library-modal-btn');
-        if (addToLibraryBtn) {
-            addToLibraryBtn.addEventListener('click', () => {
-                addMovieToLibrary({
-                    kinopoisk_id: winner.kinopoisk_id || null,
-                    name: winner.name,
-                    year: winner.year,
-                    poster: winner.poster,
-                    description: winner.description,
-                    rating_kp: winner.rating_kp,
-                    genres: winner.genres,
-                    countries: winner.countries,
-                });
-            });
-        }
-    };
-
-    const buildLibraryPayloadFromCard = (card) => {
-        if (!card) return null;
-        return {
-            kinopoisk_id: card.dataset.kinopoiskId || null,
-            name: card.dataset.movieName || '',
-            year: card.dataset.movieYear || '',
-            poster: card.dataset.moviePoster || '',
-            description: card.dataset.movieDescription || '',
-            rating_kp: card.dataset.movieRating || '',
-            genres: card.dataset.movieGenres || '',
-            countries: card.dataset.movieCountries || '',
-        };
     };
 
     const addMovieToLibrary = async (moviePayload) => {
@@ -389,30 +399,375 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    const buildLibraryPayloadFromCard = (card) => {
+        if (!card) return null;
+        return {
+            lottery_id: card.dataset.lotteryId || null,
+            kinopoisk_id: card.dataset.kinopoiskId || null,
+            name: card.dataset.movieName || '',
+            year: card.dataset.movieYear || '',
+            poster: card.dataset.moviePoster || '',
+            description: card.dataset.movieDescription || '',
+            rating_kp: card.dataset.movieRating || '',
+            genres: card.dataset.movieGenres || '',
+            countries: card.dataset.movieCountries || '',
+        };
+    };
+
+    const renderParticipantsList = (movies, winnerName) => {
+        if (!modalParticipantsContainer || !modalParticipantsList) return;
+        if (!movies || !movies.length) {
+            modalParticipantsContainer.style.display = 'none';
+            modalParticipantsList.innerHTML = '';
+            return;
+        }
+
+        modalParticipantsContainer.style.display = 'block';
+        modalParticipantsList.innerHTML = '';
+
+        movies.forEach((movie) => {
+            const item = document.createElement('li');
+            item.className = 'participant-item';
+            if (movie.name === winnerName) {
+                item.classList.add('winner');
+            }
+
+            item.innerHTML = `
+                <img class="participant-poster" src="${escapeAttr(movie.poster || placeholderPoster)}" alt="${escapeHtml(movie.name)}">
+                <span class="participant-name">${escapeHtml(movie.name)}</span>
+                <span class="participant-meta">${escapeHtml(movie.year || '')}</span>
+                ${movie.name === winnerName ? '<span class="participant-winner-badge">Победитель</span>' : ''}
+            `;
+
+            modalParticipantsList.appendChild(item);
+        });
+    };
+
+    const renderWaitingState = (data) => {
+        if (!modalWinnerInfo) return;
+        const playUrl = data.play_url;
+        const text = encodeURIComponent('Привет! Предлагаю тебе определить, какой фильм мы посмотрим. Нажми на ссылку и испытай удачу!');
+        const url = encodeURIComponent(playUrl);
+        const telegramHref = `https://t.me/share/url?url=${url}&text=${text}`;
+
+        modalWinnerInfo.innerHTML = `
+            <h3>Лотерея ожидает розыгрыша</h3>
+            <p>Поделитесь ссылкой с другом, чтобы он мог выбрать фильм.</p>
+            <div class="link-box">
+                <label for="play-link-modal">Ссылка для друга:</label>
+                <input type="text" id="play-link-modal" value="${escapeAttr(playUrl)}" readonly>
+                <button class="copy-btn" data-target="play-link-modal">Копировать</button>
+            </div>
+            <a href="${telegramHref}" class="action-button-tg" target="_blank" rel="noopener noreferrer">
+                Поделиться в Telegram
+            </a>
+        `;
+
+        const copyBtn = modalWinnerInfo.querySelector('.copy-btn');
+        if (copyBtn) {
+            copyBtn.addEventListener('click', (event) => {
+                const targetId = event.currentTarget.dataset.target;
+                const input = document.getElementById(targetId);
+                if (input) {
+                    copyToClipboard(input.value, event.currentTarget);
+                }
+            });
+        }
+    };
+
+    const handleSaveMagnet = async (lotteryId, kinopoiskId, magnetLink) => {
+        if (!kinopoiskId) {
+            alert('Не удалось определить ID фильма для сохранения magnet-ссылки.');
+            return;
+        }
+        try {
+            const response = await fetch('/api/movie-magnet', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ kinopoisk_id: kinopoiskId, magnet_link: magnetLink }),
+            });
+            const data = await response.json();
+            alert(data.message);
+            if (!response.ok || !data.success) {
+                return;
+            }
+            const refreshed = await fetchLotteryDetails(lotteryId);
+            renderLotteryDetails(refreshed);
+            if (refreshed.result) {
+                refreshCardActions(lotteryId, refreshed.result);
+            }
+        } catch (error) {
+            console.error('Ошибка при сохранении magnet-ссылки:', error);
+            alert('Произошла критическая ошибка.');
+        }
+    };
+
+    const handleDeleteLottery = async (lotteryId, cardElement) => {
+        if (!confirm('Вы уверены, что хотите удалить эту лотерею? Торрент и скачанные файлы также будут удалены из qBittorrent.')) {
+            return;
+        }
+        try {
+            const response = await fetch(`/delete-lottery/${lotteryId}`, { method: 'POST' });
+            const data = await response.json();
+            alert(data.message);
+            if (response.ok && data.success) {
+                cardElement.classList.add('is-deleting');
+                removeDownload(lotteryId);
+                setTimeout(() => {
+                    cardElement.remove();
+                    formatDateBadges();
+                }, 300);
+            }
+        } catch (error) {
+            console.error('Ошибка при удалении лотереи:', error);
+            alert('Не удалось удалить лотерею.');
+        }
+    };
+
+    const renderWinnerCard = (winner) => {
+        if (!modalWinnerInfo) return;
+
+        const ratingValue = Number.parseFloat(winner.rating_kp);
+        let ratingBadgeHtml = '';
+        if (!Number.isNaN(ratingValue)) {
+            const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
+            ratingBadgeHtml = `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>`;
+        }
+
+        modalWinnerInfo.innerHTML = `
+            <div class="winner-card">
+                <div class="winner-poster">
+                    <img src="${escapeAttr(winner.poster || placeholderPoster)}" alt="Постер ${escapeHtml(winner.name)}">
+                    ${ratingBadgeHtml}
+                </div>
+                <div class="winner-details">
+                    <h2>${escapeHtml(winner.name)}${winner.year ? ` (${escapeHtml(winner.year)})` : ''}</h2>
+                    <p class="meta-info">${escapeHtml(winner.genres || 'н/д')} / ${escapeHtml(winner.countries || 'н/д')}</p>
+                    <p class="description">${escapeHtml(winner.description || 'Описание отсутствует.')}</p>
+                    <div class="magnet-form">
+                        <label for="magnet-input">Magnet-ссылка:</label>
+                        <input type="text" id="magnet-input" value="${escapeAttr(winner.magnet_link || '')}" placeholder="Вставьте magnet-ссылку и нажмите Сохранить...">
+                        <div class="magnet-actions">
+                            <button class="action-button save-magnet-btn">Сохранить</button>
+                            ${winner.has_magnet ? '<button class="action-button-delete delete-magnet-btn">Удалить ссылку</button>' : ''}
+                        </div>
+                    </div>
+                    <button class="secondary-button add-library-modal-btn">Добавить в библиотеку</button>
+                </div>
+            </div>
+        `;
+
+        const saveBtn = modalWinnerInfo.querySelector('.save-magnet-btn');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', () => {
+                const input = modalWinnerInfo.querySelector('#magnet-input');
+                handleSaveMagnet(currentModalLotteryId, winner.kinopoisk_id, input ? input.value.trim() : '');
+            });
+        }
+
+        const deleteBtn = modalWinnerInfo.querySelector('.delete-magnet-btn');
+        if (deleteBtn) {
+            deleteBtn.addEventListener('click', () => {
+                if (confirm('Вы уверены, что хотите удалить сохраненную magnet-ссылку?')) {
+                    handleSaveMagnet(currentModalLotteryId, winner.kinopoisk_id, '');
+                }
+            });
+        }
+
+        const addToLibraryBtn = modalWinnerInfo.querySelector('.add-library-modal-btn');
+        if (addToLibraryBtn) {
+            addToLibraryBtn.addEventListener('click', () => {
+                addMovieToLibrary({
+                    lottery_id: currentModalLotteryId,
+                    kinopoisk_id: winner.kinopoisk_id || null,
+                    name: winner.name,
+                    year: winner.year,
+                    poster: winner.poster,
+                    description: winner.description,
+                    rating_kp: winner.rating_kp,
+                    genres: winner.genres,
+                    countries: winner.countries,
+                });
+            });
+        }
+    };
+
+    const renderLotteryDetails = (data) => {
+        renderParticipantsList(data.movies || [], data.result ? data.result.name : null);
+        if (data.result) {
+            renderWinnerCard(data.result);
+        } else {
+            if (modalParticipantsContainer) {
+                modalParticipantsContainer.style.display = 'none';
+            }
+            renderWaitingState(data);
+        }
+    };
+
+    const fetchLotteryDetails = async (lotteryId) => {
+        const response = await fetch(`/api/result/${lotteryId}`);
+        if (!response.ok) throw new Error('Ошибка сети');
+        const data = await response.json();
+        if (data.error) throw new Error(data.error);
+        return data;
+    };
+
+    const openModal = async (lotteryId) => {
+        if (!modalOverlay || !modalWinnerInfo) return;
+        currentModalLotteryId = lotteryId;
+        modalOverlay.style.display = 'flex';
+        modalWinnerInfo.innerHTML = '<div class="loader"></div>';
+        if (modalParticipantsContainer) {
+            modalParticipantsContainer.style.display = 'none';
+        }
+        if (modalParticipantsList) {
+            modalParticipantsList.innerHTML = '';
+        }
+
+        try {
+            const data = await fetchLotteryDetails(lotteryId);
+            renderLotteryDetails(data);
+            if (data.result) {
+                refreshCardActions(lotteryId, data.result);
+            }
+        } catch (error) {
+            modalWinnerInfo.innerHTML = `<p class="error-message">Не удалось загрузить детали: ${escapeHtml(error.message)}</p>`;
+        }
+    };
+
+    const handleSearchClick = (movieName, movieYear) => {
+        if (!movieName) return;
+        const parts = [movieName.trim()];
+        if (movieYear && movieYear.trim()) {
+            parts.push(`(${movieYear.trim()})`);
+        }
+        const query = encodeURIComponent(parts.join(' '));
+        window.open(`https://rutracker.org/forum/tracker.php?nm=${query}`, '_blank');
+    };
+
+    const handleDownloadClick = async (kinopoiskId, movieName, lotteryId) => {
+        if (!kinopoiskId) {
+            alert('Сначала добавьте magnet-ссылку для этого фильма.');
+            openModal(lotteryId);
+            return;
+        }
+        registerDownload(lotteryId, movieName, kinopoiskId);
+        try {
+            const response = await fetch(`/api/start-download/${kinopoiskId}`, { method: 'POST' });
+            const data = await response.json();
+            if (data.success) {
+                startTorrentStatusPolling(lotteryId, movieName, kinopoiskId, { skipRegister: true });
+            } else {
+                alert(`Ошибка: ${data.message}`);
+                removeDownload(lotteryId);
+            }
+        } catch (error) {
+            console.error('Ошибка при запуске скачивания:', error);
+            alert('Произошла критическая ошибка.');
+            removeDownload(lotteryId);
+        }
+    };
+
+    const collectWaitingCards = (map) => {
+        if (!gallery) return;
+        map.clear();
+        gallery.querySelectorAll('.waiting-card').forEach((card) => {
+            const lotteryId = card.dataset.lotteryId;
+            if (lotteryId) {
+                map.set(lotteryId, card);
+            }
+        });
+    };
+
+    const createCompletedCard = (lotteryId, winner, createdAtIso) => {
+        const item = document.createElement('div');
+        item.className = 'gallery-item';
+        item.dataset.lotteryId = lotteryId;
+        item.dataset.kinopoiskId = winner.kinopoisk_id || '';
+        item.dataset.movieName = winner.name || '';
+        item.dataset.movieYear = winner.year || '';
+        item.dataset.moviePoster = winner.poster || '';
+        item.dataset.movieDescription = winner.description || '';
+        item.dataset.movieRating = winner.rating_kp != null ? winner.rating_kp : '';
+        item.dataset.movieGenres = winner.genres || '';
+        item.dataset.movieCountries = winner.countries || '';
+
+        const actionButtonHtml = winner.has_magnet
+            ? '<button class="action-button download-button" title="Скачать фильм">&#x2913;</button>'
+            : '<button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>';
+
+        item.innerHTML = `
+            <div class="action-buttons">
+                ${actionButtonHtml}
+                <button class="action-button library-button" title="Добавить в библиотеку">&#128218;</button>
+                <button class="action-button-delete delete-button" title="Удалить лотерею">&times;</button>
+            </div>
+            <div class="date-badge" data-date="${escapeAttr(createdAtIso)}"></div>
+            <img src="${escapeAttr(winner.poster || placeholderPoster)}" alt="${escapeHtml(winner.name)}">
+        `;
+
+        return item;
+    };
+
+    const pollWaitingCards = (map) => async () => {
+        if (!map.size) return;
+
+        const tasks = Array.from(map.entries()).map(async ([lotteryId, cardElement]) => {
+            try {
+                const data = await fetchLotteryDetails(lotteryId);
+                if (data.result) {
+                    const newCard = createCompletedCard(lotteryId, data.result, data.createdAt);
+                    cardElement.replaceWith(newCard);
+                    refreshCardActions(lotteryId, data.result);
+                    map.delete(lotteryId);
+                    formatDateBadges();
+                } else if (modalOverlay && modalOverlay.style.display === 'flex' && currentModalLotteryId === lotteryId) {
+                    renderWaitingState(data);
+                }
+            } catch (error) {
+                console.error('Не удалось обновить лотерею', lotteryId, error);
+            }
+        });
+
+        await Promise.all(tasks);
+    };
+
     if (gallery) {
-        gallery.addEventListener('click', (e) => {
-            const galleryItem = e.target.closest('.gallery-item');
+        gallery.addEventListener('click', (event) => {
+            const galleryItem = event.target.closest('.gallery-item');
             if (!galleryItem) return;
 
             const { lotteryId, kinopoiskId, movieName, movieYear } = galleryItem.dataset;
-            const isDownloadButton = e.target.classList.contains('download-button');
-            const isSearchButton = e.target.classList.contains('search-button');
-            const isDeleteButton = e.target.classList.contains('delete-button');
-            const isLibraryButton = e.target.classList.contains('library-button');
-
-            e.stopPropagation();
+            const isDownloadButton = event.target.classList.contains('download-button');
+            const isSearchButton = event.target.classList.contains('search-button');
+            const isDeleteButton = event.target.classList.contains('delete-button');
+            const isLibraryButton = event.target.classList.contains('library-button');
 
             if (isDownloadButton) {
+                event.stopPropagation();
                 handleDownloadClick(kinopoiskId, movieName, lotteryId);
-            } else if (isSearchButton) {
-                handleSearchClick(movieName, movieYear);
-            } else if (isDeleteButton) {
-                handleDeleteLottery(lotteryId, galleryItem);
-            } else if (isLibraryButton) {
-                addMovieToLibrary(buildLibraryPayloadFromCard(galleryItem));
-            } else {
-                openModal(lotteryId);
+                return;
             }
+
+            if (isSearchButton) {
+                event.stopPropagation();
+                handleSearchClick(movieName, movieYear);
+                return;
+            }
+
+            if (isDeleteButton) {
+                event.stopPropagation();
+                handleDeleteLottery(lotteryId, galleryItem);
+                return;
+            }
+
+            if (isLibraryButton) {
+                event.stopPropagation();
+                addMovieToLibrary(buildLibraryPayloadFromCard(galleryItem));
+                return;
+            }
+
+            openModal(lotteryId);
         });
     }
 
@@ -424,84 +779,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (closeButton) closeButton.addEventListener('click', closeModal);
     if (modalOverlay) {
-        modalOverlay.addEventListener('click', (e) => {
-            if (e.target === modalOverlay) closeModal();
+        modalOverlay.addEventListener('click', (event) => {
+            if (event.target === modalOverlay) closeModal();
         });
     }
 
-    // --- АВТОМАТИЧЕСКОЕ ОБНОВЛЕНИЕ ОЖИДАЮЩИХ ЛОТЕРЕЙ ---
+    if (widgetHeader) {
+        widgetHeader.addEventListener('click', () => {
+            widget.classList.toggle('minimized');
+        });
+    }
+
+    if (widgetToggleBtn) {
+        widgetToggleBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            widget.classList.toggle('minimized');
+        });
+    }
 
     const waitingCards = new Map();
-    let waitingIntervalId = null;
-    const collectWaitingCards = () => {
-        document.querySelectorAll('.waiting-card').forEach((card) => {
-            const lotteryId = card.dataset.lotteryId;
-            if (lotteryId) {
-                waitingCards.set(lotteryId, card);
-            }
-        });
-    };
+    collectWaitingCards(waitingCards);
 
-    const createCompletedCard = (lotteryId, winner, createdAt) => {
-        const item = document.createElement('div');
-        item.className = 'gallery-item';
-        item.dataset.lotteryId = lotteryId;
-        item.dataset.kinopoiskId = winner.kinopoisk_id || '';
-        item.dataset.movieName = winner.name || '';
-        item.dataset.movieYear = winner.year || '';
-
-
-        const actionButton = winner.has_magnet
-            ? '<button class="action-button download-button" title="Скачать фильм">&#x2913;</button>'
-            : '<button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>';
-
-        item.innerHTML = `
-            <div class="action-buttons">
-                ${actionButton}
-
-
-        return item;
-    };
-
-    const pollWaitingCards = async () => {
-        if (!waitingCards.size) {
-            if (waitingIntervalId) {
-                clearInterval(waitingIntervalId);
-                waitingIntervalId = null;
-            }
-            return;
-        }
-
-        const checkCard = async (lotteryId, cardElement) => {
-            try {
-                const response = await fetch(`/api/result/${lotteryId}`);
-                if (!response.ok) return;
-                const data = await response.json();
-                if (data.result) {
-                    const newCard = createCompletedCard(lotteryId, data.result, data.createdAt);
-                    cardElement.replaceWith(newCard);
-                    waitingCards.delete(lotteryId);
-                }
-            } catch (error) {
-                console.error('Не удалось обновить лотерею', lotteryId, error);
-            }
-        };
-
-        await Promise.all(Array.from(waitingCards.entries()).map(([lotteryId, card]) => checkCard(lotteryId, card)));
-
-        if (!waitingCards.size && waitingIntervalId) {
-            clearInterval(waitingIntervalId);
-            waitingIntervalId = null;
-        }
-    };
-
-    collectWaitingCards();
     if (waitingCards.size) {
-        pollWaitingCards();
-        waitingIntervalId = setInterval(pollWaitingCards, 5000);
+        const poller = pollWaitingCards(waitingCards);
+        poller();
+        const waitingIntervalId = setInterval(() => {
+            if (!waitingCards.size) {
+                clearInterval(waitingIntervalId);
+                return;
+            }
+            poller();
+        }, 5000);
     }
 
     initializeStoredDownloads();
     ensureWidgetState();
-
+    formatDateBadges();
 });

--- a/static/js/library.js
+++ b/static/js/library.js
@@ -1,7 +1,66 @@
 // static/js/library.js
 
 document.addEventListener('DOMContentLoaded', () => {
+    const gallery = document.querySelector('.library-gallery');
+    const modalOverlay = document.getElementById('library-modal');
+    const modalBody = document.getElementById('library-modal-body');
+    const closeButton = modalOverlay ? modalOverlay.querySelector('.close-button') : null;
+    const emptyMessage = document.querySelector('.library-empty-message');
+    const placeholderPoster = 'https://via.placeholder.com/200x300.png?text=No+Image';
 
+    const formatDateBadges = () => {
+        if (!gallery) return;
+        const formatter = new Intl.DateTimeFormat('ru-RU', {
+            day: '2-digit',
+            month: 'long',
+            year: 'numeric',
+        });
+
+        gallery.querySelectorAll('.date-badge').forEach((badge) => {
+            const iso = badge.dataset.date;
+            if (!iso) return;
+
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+
+            badge.innerHTML = `<span class="calendar-icon">&#x1F4C5;</span>${formatter.format(date)}`;
+        });
+    };
+
+    const ensureEmptyState = () => {
+        if (!emptyMessage) return;
+        const hasItems = gallery && gallery.querySelector('.gallery-item');
+        emptyMessage.style.display = hasItems ? 'none' : 'block';
+    };
+
+    const closeModal = () => {
+        if (!modalOverlay) return;
+        modalOverlay.style.display = 'none';
+        document.body.classList.remove('no-scroll');
+    };
+
+    const handleSearch = (name, year) => {
+        if (!name) return;
+        const parts = [name.trim()];
+        if (year && year.trim()) {
+            parts.push(`(${year.trim()})`);
+        }
+        const query = encodeURIComponent(parts.join(' '));
+        window.open(`https://rutracker.org/forum/tracker.php?nm=${query}`, '_blank');
+    };
+
+    const removeCardFromDom = (card) => {
+        if (!card) return;
+        card.classList.add('is-deleting');
+        setTimeout(() => {
+            card.remove();
+            ensureEmptyState();
+        }, 300);
+    };
+
+    const handleDelete = async (card) => {
+        if (!card) return;
+        const movieId = card.dataset.movieId;
         if (!movieId) return;
 
         if (!confirm('Удалить фильм из библиотеки?')) {
@@ -15,6 +74,97 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(data.message || 'Не удалось удалить фильм.');
             }
 
+            closeModal();
+            removeCardFromDom(card);
+        } catch (error) {
+            alert(error.message);
         }
-    });
+    };
+
+    const renderModal = (card) => {
+        if (!modalOverlay || !modalBody || !card) return;
+        const {
+            movieName = 'Неизвестный фильм',
+            movieYear = '',
+            moviePoster = '',
+            movieDescription = '',
+            movieGenres = '',
+            movieCountries = '',
+            movieRating = '',
+        } = card.dataset;
+
+        const ratingValue = parseFloat(movieRating);
+        let ratingBadge = '';
+        if (!Number.isNaN(ratingValue)) {
+            const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
+            ratingBadge = `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>`;
+        }
+
+        modalBody.innerHTML = `
+            <div class="winner-card">
+                <div class="winner-poster">
+                    <img src="${moviePoster || placeholderPoster}" alt="Постер ${movieName}">
+                    ${ratingBadge}
+                </div>
+                <div class="winner-details">
+                    <h2>${movieName}${movieYear ? ` (${movieYear})` : ''}</h2>
+                    <p class="meta-info">${movieGenres || 'н/д'} / ${movieCountries || 'н/д'}</p>
+                    <p class="description">${movieDescription || 'Описание отсутствует.'}</p>
+                    <div class="library-modal-actions">
+                        <button class="secondary-button modal-search-btn">Искать торрент</button>
+                        <button class="danger-button modal-delete-btn">Удалить из библиотеки</button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        const searchBtn = modalBody.querySelector('.modal-search-btn');
+        if (searchBtn) {
+            searchBtn.addEventListener('click', () => handleSearch(movieName, movieYear));
+        }
+
+        const deleteBtn = modalBody.querySelector('.modal-delete-btn');
+        if (deleteBtn) {
+            deleteBtn.addEventListener('click', () => handleDelete(card));
+        }
+
+        modalOverlay.style.display = 'flex';
+        document.body.classList.add('no-scroll');
+    };
+
+    if (gallery) {
+        gallery.addEventListener('click', (event) => {
+            const card = event.target.closest('.gallery-item');
+            if (!card) return;
+
+            if (event.target.classList.contains('search-button')) {
+                event.stopPropagation();
+                handleSearch(card.dataset.movieName, card.dataset.movieYear);
+                return;
+            }
+
+            if (event.target.classList.contains('delete-button')) {
+                event.stopPropagation();
+                handleDelete(card);
+                return;
+            }
+
+            renderModal(card);
+        });
+    }
+
+    if (closeButton) {
+        closeButton.addEventListener('click', closeModal);
+    }
+
+    if (modalOverlay) {
+        modalOverlay.addEventListener('click', (event) => {
+            if (event.target === modalOverlay) {
+                closeModal();
+            }
+        });
+    }
+
+    formatDateBadges();
+    ensureEmptyState();
 });

--- a/templates/library.html
+++ b/templates/library.html
@@ -20,14 +20,40 @@
         </div>
     </header>
 
-
+    <div class="history-gallery library-gallery">
+        {% if library_movies %}
+            {% for movie in library_movies %}
+                <div
+                    class="gallery-item library-card"
+                    data-movie-id="{{ movie.id }}"
+                    data-movie-name="{{ movie.name|e }}"
+                    data-movie-year="{{ movie.year or '' }}"
+                    data-movie-poster="{{ (movie.poster or '')|e }}"
+                    data-movie-description="{{ (movie.description|default('', true)|replace('\n', ' '))|e }}"
+                    data-movie-rating="{{ '%.1f'|format(movie.rating_kp) if movie.rating_kp is not none else '' }}"
+                    data-movie-genres="{{ (movie.genres|default('', true))|e }}"
+                    data-movie-countries="{{ (movie.countries|default('', true))|e }}"
+                    data-added-at="{{ movie.added_at.isoformat() }}"
+                >
+                    <div class="action-buttons">
+                        <button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>
+                        <button class="action-button-delete delete-button" title="Удалить из библиотеки">&times;</button>
+                    </div>
+                    <div class="date-badge" data-date="{{ movie.added_at.isoformat() }}"></div>
+                    <img src="{{ movie.poster or 'https://via.placeholder.com/200x300.png?text=No+Image' }}" alt="{{ movie.name|e }}">
                 </div>
             {% endfor %}
-        {% else %}
-            <p class="no-history">В библиотеке пока нет фильмов.</p>
         {% endif %}
     </div>
 
+    <p class="no-history library-empty-message"{% if library_movies %} style="display: none;"{% endif %}>В библиотеке пока нет фильмов.</p>
+
+    <div id="library-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <div id="library-modal-body"></div>
+        </div>
+    </div>
 
     <script src="{{ url_for('static', filename='js/library.js') }}"></script>
     <script>


### PR DESCRIPTION
## Summary
- rebuild the history page script so clicking a lottery card opens the detailed modal with participants, magnet editing, add-to-library, and Telegram sharing for waiting draws
- restore torrent status widget persistence, download polling, and card action updates when magnet links change

## Testing
- pytest *(fails: SyntaxError in tests/test_torrent_status.py because the repository still contains an incomplete patch in that test file)*

------
https://chatgpt.com/codex/tasks/task_e_68cf94fcedf08328939e1ad217817d50