### PR TITLE
Enhance library torrent management

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -317,24 +317,18 @@ button:disabled {
 .gallery-item:hover img { transform: scale(1.05); filter: brightness(1.1); }
 .date-badge {
     position: absolute;
-    top: 48px;
-    right: 8px;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    border-radius: 20px;
-    background-color: rgba(0, 0, 0, 0.7);
-    color: white;
-    font-size: 13px;
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    padding: 0;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 14px;
     font-weight: 600;
-    letter-spacing: 0.3px;
-    transition: opacity 0.3s ease;
+    letter-spacing: 0.2px;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
     pointer-events: none;
     z-index: 2;
 }
-.gallery-item:hover .date-badge, .waiting-card:hover .date-badge { opacity: 0; }
-.date-badge .calendar-icon { font-size: 15px; }
 .no-history { grid-column: 1 / -1; text-align: center; font-size: 1.2em; color: #adb5bd; padding: 50px; }
 .waiting-card { background-color: #2b2b2b; display: flex; justify-content: center; align-items: center; text-align: center; color: #adb5bd; transition: background-color 0.4s; }
 .waiting-card:hover { background-color: #343a40; }
@@ -342,7 +336,9 @@ button:disabled {
 .waiting-card.is-updating .waiting-content { opacity: 0; }
 .waiting-content .loader-small { border: 3px solid #6c757d; border-top: 3px solid var(--primary-color); border-radius: 50%; width: 30px; height: 30px; animation: spin 1s linear infinite; margin: 0 auto 10px; }
 .waiting-content span { font-weight: 700; }
-.waiting-card .date-badge { top: 12px; }
+.waiting-card .date-badge {
+    bottom: 16px;
+}
 
 
 
@@ -357,6 +353,74 @@ button:disabled {
     overflow-y: auto;
     position: relative;
     animation: zoomIn 0.3s ease-out;
+}
+.library-modal-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 20px;
+}
+
+.download-status {
+    margin-top: 24px;
+    padding: 16px;
+    border-radius: 12px;
+    background-color: rgba(255, 255, 255, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.status-progress-track {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background-color: rgba(255, 255, 255, 0.12);
+    overflow: hidden;
+}
+
+.status-progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 0%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--primary-color), #ff8a00);
+    transition: width 0.3s ease;
+}
+
+.status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 8px 16px;
+    font-size: 13px;
+    color: #dee2e6;
+}
+
+.status-grid .status-label {
+    color: rgba(255, 255, 255, 0.6);
+    font-weight: 600;
+}
+
+.danger-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 8px;
+    border: none;
+    background-color: var(--danger-color);
+    color: var(--secondary-color);
+    font-weight: 700;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.danger-button:hover {
+    background-color: #b02a37;
+    transform: translateY(-1px);
 }
 .close-button { position: absolute; top: 10px; right: 20px; font-size: 30px; color: #adb5bd; cursor: pointer; transition: color 0.2s; }
 .close-button:hover { color: white; }

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -3,20 +3,145 @@
 document.addEventListener('DOMContentLoaded', () => {
     const gallery = document.querySelector('.history-gallery');
     const modalOverlay = document.getElementById('history-modal');
-    const closeButton = document.querySelector('.close-button');
+    const closeButton = modalOverlay ? modalOverlay.querySelector('.close-button') : null;
     const modalWinnerInfo = document.getElementById('modal-winner-info');
     const modalParticipantsContainer = document.getElementById('modal-participants');
     const modalParticipantsList = modalParticipantsContainer ? modalParticipantsContainer.querySelector('.participants-list') : null;
 
     const widget = document.getElementById('torrent-status-widget');
     const widgetHeader = widget ? widget.querySelector('.widget-header') : null;
+    const widgetToggleBtn = widget ? widget.querySelector('#widget-toggle-btn') : null;
     const widgetDownloadsContainer = widget ? widget.querySelector('#widget-downloads') : null;
     const widgetEmptyText = widget ? widget.querySelector('.widget-empty') : null;
 
     const ACTIVE_DOWNLOADS_KEY = 'lotteryActiveDownloads';
+    const placeholderPoster = 'https://via.placeholder.com/200x300.png?text=No+Image';
+
     const pollIntervals = new Map();
     const activeDownloads = new Map();
 
+    let currentModalLotteryId = null;
+
+    const escapeHtml = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    };
+
+    const escapeAttr = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;');
+    };
+
+    const safeJsonParse = (value) => {
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const saveActiveDownloads = () => {
+        if (!widget) return;
+        try {
+            const payload = Array.from(activeDownloads.values()).map((entry) => ({
+                lotteryId: entry.lotteryId,
+                movieName: entry.movieName,
+                kinopoiskId: entry.kinopoiskId || null,
+            }));
+            localStorage.setItem(ACTIVE_DOWNLOADS_KEY, JSON.stringify(payload));
+        } catch (error) {
+            console.warn('Не удалось сохранить активные загрузки:', error);
+        }
+    };
+
+    const loadStoredDownloads = () => {
+        if (!widget) return [];
+        try {
+            const raw = localStorage.getItem(ACTIVE_DOWNLOADS_KEY);
+            if (!raw) return [];
+            const parsed = safeJsonParse(raw);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+            console.warn('Не удалось восстановить активные загрузки:', error);
+            localStorage.removeItem(ACTIVE_DOWNLOADS_KEY);
+            return [];
+        }
+    };
+
+    const ensureWidgetState = () => {
+        if (!widget) return;
+        const hasDownloads = activeDownloads.size > 0;
+        widget.style.display = hasDownloads ? 'block' : 'none';
+        if (widgetEmptyText) {
+            widgetEmptyText.style.display = hasDownloads ? 'none' : 'block';
+        }
+        if (widgetDownloadsContainer) {
+            widgetDownloadsContainer.style.display = hasDownloads ? 'block' : 'none';
+        }
+        if (hasDownloads) {
+            widget.classList.remove('minimized');
+        }
+    };
+
+    const getOrCreateDownloadElement = (lotteryId) => {
+        if (!widgetDownloadsContainer) return null;
+        let item = widgetDownloadsContainer.querySelector(`[data-lottery-id="${lotteryId}"]`);
+        if (!item) {
+            item = document.createElement('div');
+            item.className = 'widget-download';
+            item.dataset.lotteryId = lotteryId;
+            item.innerHTML = `
+                <h5 class="widget-download-title"></h5>
+                <div class="progress-bar-container">
+                    <div class="progress-bar"></div>
+                </div>
+                <div class="widget-stats">
+                    <span class="progress-text">0%</span>
+                    <span class="speed-text">0.00 МБ/с</span>
+                    <span class="eta-text">--:--</span>
+                </div>
+                <div class="widget-stats-bottom">
+                    <span class="peers-text">Сиды: 0 / Пиры: 0</span>
+                </div>
+            `;
+            widgetDownloadsContainer.appendChild(item);
+        }
+        return item;
+    };
+
+    const registerDownload = (lotteryId, movieName, kinopoiskId, { skipSave = false } = {}) => {
+        if (!widget || !lotteryId) return null;
+        const existing = activeDownloads.get(lotteryId) || {};
+        const updated = {
+            lotteryId,
+            movieName: movieName || existing.movieName || 'Загрузка...',
+            kinopoiskId: kinopoiskId || existing.kinopoiskId || null,
+        };
+        activeDownloads.set(lotteryId, updated);
+
+        const element = getOrCreateDownloadElement(lotteryId);
+        if (element) {
+            const title = element.querySelector('.widget-download-title');
+            if (title) {
+                title.textContent = `Загрузка: ${updated.movieName}`;
+            }
+        }
+
+        ensureWidgetState();
+        if (!skipSave) saveActiveDownloads();
+        return updated;
+    };
 
     const removeDownload = (lotteryId) => {
         if (pollIntervals.has(lotteryId)) {
@@ -70,11 +195,12 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        if (bar) bar.style.width = `${data.progress}%`;
-        if (progressText) progressText.textContent = `${data.progress}%`;
-        if (speedText) speedText.textContent = `${data.speed} МБ/с`;
-        if (etaText) etaText.textContent = data.eta;
-        if (peersText) peersText.textContent = `Сиды: ${data.seeds} / Пиры: ${data.peers}`;
+        const progressValue = Number.parseFloat(data.progress) || 0;
+        if (bar) bar.style.width = `${Math.min(100, Math.max(0, progressValue))}%`;
+        if (progressText) progressText.textContent = `${progressValue.toFixed(0)}%`;
+        if (speedText) speedText.textContent = data.speed ? `${data.speed} МБ/с` : '0.00 МБ/с';
+        if (etaText) etaText.textContent = data.eta || '--:--';
+        if (peersText) peersText.textContent = `Сиды: ${data.seeds ?? 0} / Пиры: ${data.peers ?? 0}`;
     };
 
     const markDownloadCompleted = (lotteryId) => {
@@ -97,9 +223,11 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => removeDownload(lotteryId), 5000);
     };
 
-    const startTorrentStatusPolling = (lotteryId, movieName, kinopoiskId) => {
+    const startTorrentStatusPolling = (lotteryId, movieName, kinopoiskId, { skipRegister = false } = {}) => {
         if (!lotteryId) return;
-        registerDownload(lotteryId, movieName, kinopoiskId);
+        if (!skipRegister) {
+            registerDownload(lotteryId, movieName, kinopoiskId);
+        }
 
         if (pollIntervals.has(lotteryId)) {
             clearInterval(pollIntervals.get(lotteryId));
@@ -108,6 +236,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const poll = async () => {
             try {
                 const response = await fetch(`/api/torrent-status/${lotteryId}`);
+                if (!response.ok) {
+                    throw new Error('Сервер вернул ошибку статуса');
+                }
                 const data = await response.json();
 
                 if (data.status === 'error') {
@@ -115,7 +246,21 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (pollIntervals.has(lotteryId)) {
                         clearInterval(pollIntervals.get(lotteryId));
                         pollIntervals.delete(lotteryId);
+                    }
+                    return;
+                }
 
+                updateDownloadView(lotteryId, data);
+
+                const progressValue = Number.parseFloat(data.progress) || 0;
+                const statusText = (data.status || '').toLowerCase();
+                const isCompleted = progressValue >= 100 || statusText.includes('seeding') || statusText.includes('completed');
+
+                if (isCompleted) {
+                    if (pollIntervals.has(lotteryId)) {
+                        clearInterval(pollIntervals.get(lotteryId));
+                        pollIntervals.delete(lotteryId);
+                    }
                     markDownloadCompleted(lotteryId);
                 }
             } catch (error) {
@@ -131,244 +276,108 @@ document.addEventListener('DOMContentLoaded', () => {
         poll();
         const intervalId = setInterval(poll, 3000);
         pollIntervals.set(lotteryId, intervalId);
-
-    if (widgetHeader) {
-        widgetHeader.addEventListener('click', () => {
-            widget.classList.toggle('minimized');
-        });
-    }
-
-    // --- ЛОГИКА ВЗАИМОДЕЙСТВИЯ С КНОПКАМИ КАРТОЧЕК ---
-
-    const handleSearchClick = (movieName, movieYear) => {
-        const query = encodeURIComponent(`${movieName} (${movieYear})`);
-        const searchUrl = `https://rutracker.org/forum/tracker.php?nm=${query}`;
-        window.open(searchUrl, '_blank');
     };
 
-    const handleDownloadClick = async (kinopoiskId, movieName, lotteryId) => {
-        registerDownload(lotteryId, movieName, kinopoiskId);
-        try {
-            const response = await fetch(`/api/start-download/${kinopoiskId}`, { method: 'POST' });
-            const data = await response.json();
-            if (data.success) {
-                startTorrentStatusPolling(lotteryId, movieName, kinopoiskId);
-            } else {
-                alert(`Ошибка: ${data.message}`);
-                removeDownload(lotteryId);
-            }
-        } catch (error) {
-            console.error('Ошибка при запуске скачивания:', error);
-            alert('Произошла критическая ошибка.');
-            removeDownload(lotteryId);
-        }
-    };
-
-    const handleSaveMagnet = async (kinopoiskId, magnetLink) => {
-        try {
-            const response = await fetch('/api/movie-magnet', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ kinopoisk_id: kinopoiskId, magnet_link: magnetLink })
-            });
-            const data = await response.json();
-            alert(data.message);
-            if (data.success) {
-                closeModal();
-                location.reload();
-            }
-        } catch (error) {
-            console.error('Ошибка при сохранении magnet-ссылки:', error);
-            alert('Произошла критическая ошибка.');
-        }
-    };
-
-    const handleDeleteLottery = async (lotteryId, cardElement) => {
-        if (!confirm('Вы уверены, что хотите удалить эту лотерею? Торрент и скачанные файлы также будут удалены из qBittorrent.')) {
-            return;
-        }
-        try {
-            const response = await fetch(`/delete-lottery/${lotteryId}`, { method: 'POST' });
-            const data = await response.json();
-            alert(data.message);
-            if (data.success) {
-                cardElement.classList.add('is-deleting');
-                removeDownload(lotteryId);
-                setTimeout(() => cardElement.remove(), 500);
-            }
-        } catch (error) {
-            console.error('Ошибка при удалении лотереи:', error);
-            alert('Не удалось удалить лотерею.');
-        }
-    };
-
-    // --- МОДАЛЬНОЕ ОКНО ---
-
-    const renderParticipantsList = (movies, winnerName) => {
-        if (!modalParticipantsContainer || !modalParticipantsList) return;
-        if (!movies || !movies.length) {
-            modalParticipantsContainer.style.display = 'none';
-            modalParticipantsList.innerHTML = '';
-            return;
-        }
-
-        modalParticipantsContainer.style.display = 'block';
-        modalParticipantsList.innerHTML = '';
-
-        movies.forEach((movie) => {
-            const item = document.createElement('li');
-            item.className = 'participant-item';
-            if (movie.name === winnerName) {
-                item.classList.add('winner');
-            }
-
-            item.innerHTML = `
-                <img class="participant-poster" src="${movie.poster || 'https://via.placeholder.com/100x150.png?text=No+Image'}" alt="${movie.name}">
-                <span class="participant-name">${movie.name}</span>
-                <span class="participant-meta">${movie.year || ''}</span>
-                ${movie.name === winnerName ? '<span class="participant-winner-badge">Победитель</span>' : ''}
-            `;
-
-            modalParticipantsList.appendChild(item);
+    const initializeStoredDownloads = () => {
+        if (!widget) return;
+        const stored = loadStoredDownloads();
+        stored.forEach((entry) => {
+            if (!entry || !entry.lotteryId) return;
+            startTorrentStatusPolling(entry.lotteryId, entry.movieName, entry.kinopoiskId);
         });
     };
 
-    const openModal = async (lotteryId) => {
-        if (!modalOverlay) return;
-        modalOverlay.style.display = 'flex';
-        modalWinnerInfo.innerHTML = '<div class="loader"></div>';
-        if (modalParticipantsContainer) {
-            modalParticipantsContainer.style.display = 'none';
-        }
-        if (modalParticipantsList) {
-            modalParticipantsList.innerHTML = '';
+    const formatDateBadges = () => {
+        if (!gallery) return;
+
+        gallery.querySelectorAll('.date-badge').forEach((badge) => {
+            const iso = badge.dataset.date;
+            if (!iso) return;
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+
+            const day = String(date.getDate()).padStart(2, '0');
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const year = date.getFullYear();
+            badge.textContent = `${day}.${month}.${year}`;
+        });
+    };
+
+    const refreshCardActions = (lotteryId, winner) => {
+        if (!gallery) return;
+        const card = gallery.querySelector(`.gallery-item[data-lottery-id="${lotteryId}"]`);
+        if (!card) return;
+
+        if (winner) {
+            card.dataset.kinopoiskId = winner.kinopoisk_id || '';
+            card.dataset.movieName = winner.name || '';
+            card.dataset.movieYear = winner.year || '';
+            card.dataset.moviePoster = winner.poster || '';
+            card.dataset.movieDescription = winner.description || '';
+            card.dataset.movieRating = winner.rating_kp != null ? winner.rating_kp : '';
+            card.dataset.movieGenres = winner.genres || '';
+            card.dataset.movieCountries = winner.countries || '';
         }
 
+        const buttons = card.querySelector('.action-buttons');
+        if (!buttons) return;
+
+        const existingDownloadBtn = buttons.querySelector('.download-button');
+        const existingSearchBtn = buttons.querySelector('.search-button');
+
+        if (winner && winner.has_magnet) {
+            if (existingSearchBtn) {
+                const downloadBtn = document.createElement('button');
+                downloadBtn.className = 'action-button download-button';
+                downloadBtn.title = 'Скачать фильм';
+                downloadBtn.innerHTML = '&#x2913;';
+                buttons.replaceChild(downloadBtn, existingSearchBtn);
+            } else if (!existingDownloadBtn) {
+                const downloadBtn = document.createElement('button');
+                downloadBtn.className = 'action-button download-button';
+                downloadBtn.title = 'Скачать фильм';
+                downloadBtn.innerHTML = '&#x2913;';
+                buttons.insertBefore(downloadBtn, buttons.firstChild);
+            }
+        } else {
+            if (existingDownloadBtn) {
+                const searchBtn = document.createElement('button');
+                searchBtn.className = 'action-button search-button';
+                searchBtn.title = 'Искать торрент';
+                searchBtn.innerHTML = '&#x1F50D;';
+                buttons.replaceChild(searchBtn, existingDownloadBtn);
+            } else if (!existingSearchBtn) {
+                const searchBtn = document.createElement('button');
+                searchBtn.className = 'action-button search-button';
+                searchBtn.title = 'Искать торрент';
+                searchBtn.innerHTML = '&#x1F50D;';
+                buttons.insertBefore(searchBtn, buttons.firstChild);
+            }
+        }
+    };
+
+    const copyToClipboard = async (value, feedbackTarget) => {
         try {
-            const response = await fetch(`/api/result/${lotteryId}`);
-            if (!response.ok) throw new Error('Ошибка сети');
-            const data = await response.json();
-            if (data.error) throw new Error(data.error);
-
-            renderParticipantsList(data.movies || [], data.result ? data.result.name : null);
-
-            if (data.result) {
-                renderWinnerCard(data.result);
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(value);
             } else {
-                const playUrl = data.play_url;
-                const text = encodeURIComponent('Привет! Предлагаю тебе определить, какой фильм мы посмотрим. Нажми на ссылку и испытай удачу!');
-                const url = encodeURIComponent(playUrl);
-                const telegramHref = `https://t.me/share/url?url=${url}&text=${text}`;
-
-                modalWinnerInfo.innerHTML = `
-                    <h3>Лотерея ожидает розыгрыша</h3>
-                    <p>Поделитесь ссылкой с другом, чтобы он мог выбрать фильм.</p>
-                    <div class="link-box">
-                        <label for="play-link-modal">Ссылка для друга:</label>
-                        <input type="text" id="play-link-modal" value="${playUrl}" readonly>
-                        <button class="copy-btn" data-target="play-link-modal">Копировать</button>
-                    </div>
-                    <a href="${telegramHref}" class="action-button-tg" target="_blank">
-                        Поделиться в Telegram
-                    </a>
-                `;
-
-                const copyBtn = modalWinnerInfo.querySelector('.copy-btn');
-                if (copyBtn) {
-                    copyBtn.addEventListener('click', (e) => {
-                        const targetId = e.target.dataset.target;
-                        const input = document.getElementById(targetId);
-                        if (!input) return;
-                        input.select();
-                        document.execCommand('copy');
-                        e.target.textContent = 'Скопировано!';
-                        setTimeout(() => { e.target.textContent = 'Копировать'; }, 2000);
-                    });
-                }
+                const tempInput = document.createElement('input');
+                tempInput.value = value;
+                document.body.appendChild(tempInput);
+                tempInput.select();
+                document.execCommand('copy');
+                document.body.removeChild(tempInput);
+            }
+            if (feedbackTarget) {
+                const original = feedbackTarget.textContent;
+                feedbackTarget.textContent = 'Скопировано!';
+                setTimeout(() => {
+                    feedbackTarget.textContent = original;
+                }, 2000);
             }
         } catch (error) {
-            modalWinnerInfo.innerHTML = `<p class="error-message">Не удалось загрузить детали: ${error.message}</p>`;
+            console.error('Не удалось скопировать ссылку:', error);
         }
-    };
-
-    const renderWinnerCard = (winner) => {
-        const ratingValue = typeof winner.rating_kp === 'number' ? winner.rating_kp : 0;
-        const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
-        const ratingBadgeHtml = ratingValue ? `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>` : '';
-
-        const magnetFormHtml = `
-            <div class="magnet-form">
-                <label for="magnet-input">Magnet-ссылка:</label>
-                <input type="text" id="magnet-input" value="${winner.magnet_link || ''}" placeholder="Вставьте magnet-ссылку и нажмите Сохранить...">
-                <div class="magnet-actions">
-                    <button class="action-button save-magnet-btn">Сохранить</button>
-                    ${winner.has_magnet ? '<button class="action-button-delete delete-magnet-btn">Удалить ссылку</button>' : ''}
-                </div>
-            </div>
-            <button class="secondary-button add-library-modal-btn">Добавить в библиотеку</button>
-        `;
-
-        modalWinnerInfo.innerHTML = `
-            <div class="winner-card">
-                <div class="winner-poster">
-                    <img src="${winner.poster || ''}" alt="Постер ${winner.name}">
-                    ${ratingBadgeHtml}
-                </div>
-                <div class="winner-details">
-                    <h2>${winner.name} (${winner.year})</h2>
-                    <p class="meta-info">${winner.genres || 'н/д'} / ${winner.countries || 'н/д'}</p>
-                    <p class="description">${winner.description || 'Описание отсутствует.'}</p>
-                    ${magnetFormHtml}
-                </div>
-            </div>
-        `;
-
-        const saveBtn = modalWinnerInfo.querySelector('.save-magnet-btn');
-        if (saveBtn) {
-            saveBtn.addEventListener('click', () => {
-                const input = modalWinnerInfo.querySelector('#magnet-input');
-                handleSaveMagnet(winner.kinopoisk_id, input ? input.value : '');
-            });
-        }
-
-        const deleteBtn = modalWinnerInfo.querySelector('.delete-magnet-btn');
-        if (deleteBtn) {
-            deleteBtn.addEventListener('click', () => {
-                if (confirm('Вы уверены, что хотите удалить сохраненную magnet-ссылку?')) {
-                    handleSaveMagnet(winner.kinopoisk_id, '');
-                }
-            });
-        }
-
-        const addToLibraryBtn = modalWinnerInfo.querySelector('.add-library-modal-btn');
-        if (addToLibraryBtn) {
-            addToLibraryBtn.addEventListener('click', () => {
-                addMovieToLibrary({
-                    kinopoisk_id: winner.kinopoisk_id || null,
-                    name: winner.name,
-                    year: winner.year,
-                    poster: winner.poster,
-                    description: winner.description,
-                    rating_kp: winner.rating_kp,
-                    genres: winner.genres,
-                    countries: winner.countries,
-                });
-            });
-        }
-    };
-
-    const buildLibraryPayloadFromCard = (card) => {
-        if (!card) return null;
-        return {
-            kinopoisk_id: card.dataset.kinopoiskId || null,
-            name: card.dataset.movieName || '',
-            year: card.dataset.movieYear || '',
-            poster: card.dataset.moviePoster || '',
-            description: card.dataset.movieDescription || '',
-            rating_kp: card.dataset.movieRating || '',
-            genres: card.dataset.movieGenres || '',
-            countries: card.dataset.movieCountries || '',
-        };
     };
 
     const addMovieToLibrary = async (moviePayload) => {
@@ -389,30 +398,375 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    const buildLibraryPayloadFromCard = (card) => {
+        if (!card) return null;
+        return {
+            lottery_id: card.dataset.lotteryId || null,
+            kinopoisk_id: card.dataset.kinopoiskId || null,
+            name: card.dataset.movieName || '',
+            year: card.dataset.movieYear || '',
+            poster: card.dataset.moviePoster || '',
+            description: card.dataset.movieDescription || '',
+            rating_kp: card.dataset.movieRating || '',
+            genres: card.dataset.movieGenres || '',
+            countries: card.dataset.movieCountries || '',
+        };
+    };
+
+    const renderParticipantsList = (movies, winnerName) => {
+        if (!modalParticipantsContainer || !modalParticipantsList) return;
+        if (!movies || !movies.length) {
+            modalParticipantsContainer.style.display = 'none';
+            modalParticipantsList.innerHTML = '';
+            return;
+        }
+
+        modalParticipantsContainer.style.display = 'block';
+        modalParticipantsList.innerHTML = '';
+
+        movies.forEach((movie) => {
+            const item = document.createElement('li');
+            item.className = 'participant-item';
+            if (movie.name === winnerName) {
+                item.classList.add('winner');
+            }
+
+            item.innerHTML = `
+                <img class="participant-poster" src="${escapeAttr(movie.poster || placeholderPoster)}" alt="${escapeHtml(movie.name)}">
+                <span class="participant-name">${escapeHtml(movie.name)}</span>
+                <span class="participant-meta">${escapeHtml(movie.year || '')}</span>
+                ${movie.name === winnerName ? '<span class="participant-winner-badge">Победитель</span>' : ''}
+            `;
+
+            modalParticipantsList.appendChild(item);
+        });
+    };
+
+    const renderWaitingState = (data) => {
+        if (!modalWinnerInfo) return;
+        const playUrl = data.play_url;
+        const text = encodeURIComponent('Привет! Предлагаю тебе определить, какой фильм мы посмотрим. Нажми на ссылку и испытай удачу!');
+        const url = encodeURIComponent(playUrl);
+        const telegramHref = `https://t.me/share/url?url=${url}&text=${text}`;
+
+        modalWinnerInfo.innerHTML = `
+            <h3>Лотерея ожидает розыгрыша</h3>
+            <p>Поделитесь ссылкой с другом, чтобы он мог выбрать фильм.</p>
+            <div class="link-box">
+                <label for="play-link-modal">Ссылка для друга:</label>
+                <input type="text" id="play-link-modal" value="${escapeAttr(playUrl)}" readonly>
+                <button class="copy-btn" data-target="play-link-modal">Копировать</button>
+            </div>
+            <a href="${telegramHref}" class="action-button-tg" target="_blank" rel="noopener noreferrer">
+                Поделиться в Telegram
+            </a>
+        `;
+
+        const copyBtn = modalWinnerInfo.querySelector('.copy-btn');
+        if (copyBtn) {
+            copyBtn.addEventListener('click', (event) => {
+                const targetId = event.currentTarget.dataset.target;
+                const input = document.getElementById(targetId);
+                if (input) {
+                    copyToClipboard(input.value, event.currentTarget);
+                }
+            });
+        }
+    };
+
+    const handleSaveMagnet = async (lotteryId, kinopoiskId, magnetLink) => {
+        if (!kinopoiskId) {
+            alert('Не удалось определить ID фильма для сохранения magnet-ссылки.');
+            return;
+        }
+        try {
+            const response = await fetch('/api/movie-magnet', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ kinopoisk_id: kinopoiskId, magnet_link: magnetLink }),
+            });
+            const data = await response.json();
+            alert(data.message);
+            if (!response.ok || !data.success) {
+                return;
+            }
+            const refreshed = await fetchLotteryDetails(lotteryId);
+            renderLotteryDetails(refreshed);
+            if (refreshed.result) {
+                refreshCardActions(lotteryId, refreshed.result);
+            }
+        } catch (error) {
+            console.error('Ошибка при сохранении magnet-ссылки:', error);
+            alert('Произошла критическая ошибка.');
+        }
+    };
+
+    const handleDeleteLottery = async (lotteryId, cardElement) => {
+        if (!confirm('Вы уверены, что хотите удалить эту лотерею? Торрент и скачанные файлы также будут удалены из qBittorrent.')) {
+            return;
+        }
+        try {
+            const response = await fetch(`/delete-lottery/${lotteryId}`, { method: 'POST' });
+            const data = await response.json();
+            alert(data.message);
+            if (response.ok && data.success) {
+                cardElement.classList.add('is-deleting');
+                removeDownload(lotteryId);
+                setTimeout(() => {
+                    cardElement.remove();
+                    formatDateBadges();
+                }, 300);
+            }
+        } catch (error) {
+            console.error('Ошибка при удалении лотереи:', error);
+            alert('Не удалось удалить лотерею.');
+        }
+    };
+
+    const renderWinnerCard = (winner) => {
+        if (!modalWinnerInfo) return;
+
+        const ratingValue = Number.parseFloat(winner.rating_kp);
+        let ratingBadgeHtml = '';
+        if (!Number.isNaN(ratingValue)) {
+            const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
+            ratingBadgeHtml = `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>`;
+        }
+
+        modalWinnerInfo.innerHTML = `
+            <div class="winner-card">
+                <div class="winner-poster">
+                    <img src="${escapeAttr(winner.poster || placeholderPoster)}" alt="Постер ${escapeHtml(winner.name)}">
+                    ${ratingBadgeHtml}
+                </div>
+                <div class="winner-details">
+                    <h2>${escapeHtml(winner.name)}${winner.year ? ` (${escapeHtml(winner.year)})` : ''}</h2>
+                    <p class="meta-info">${escapeHtml(winner.genres || 'н/д')} / ${escapeHtml(winner.countries || 'н/д')}</p>
+                    <p class="description">${escapeHtml(winner.description || 'Описание отсутствует.')}</p>
+                    <div class="magnet-form">
+                        <label for="magnet-input">Magnet-ссылка:</label>
+                        <input type="text" id="magnet-input" value="${escapeAttr(winner.magnet_link || '')}" placeholder="Вставьте magnet-ссылку и нажмите Сохранить...">
+                        <div class="magnet-actions">
+                            <button class="action-button save-magnet-btn">Сохранить</button>
+                            ${winner.has_magnet ? '<button class="action-button-delete delete-magnet-btn">Удалить ссылку</button>' : ''}
+                        </div>
+                    </div>
+                    <button class="secondary-button add-library-modal-btn">Добавить в библиотеку</button>
+                </div>
+            </div>
+        `;
+
+        const saveBtn = modalWinnerInfo.querySelector('.save-magnet-btn');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', () => {
+                const input = modalWinnerInfo.querySelector('#magnet-input');
+                handleSaveMagnet(currentModalLotteryId, winner.kinopoisk_id, input ? input.value.trim() : '');
+            });
+        }
+
+        const deleteBtn = modalWinnerInfo.querySelector('.delete-magnet-btn');
+        if (deleteBtn) {
+            deleteBtn.addEventListener('click', () => {
+                if (confirm('Вы уверены, что хотите удалить сохраненную magnet-ссылку?')) {
+                    handleSaveMagnet(currentModalLotteryId, winner.kinopoisk_id, '');
+                }
+            });
+        }
+
+        const addToLibraryBtn = modalWinnerInfo.querySelector('.add-library-modal-btn');
+        if (addToLibraryBtn) {
+            addToLibraryBtn.addEventListener('click', () => {
+                addMovieToLibrary({
+                    lottery_id: currentModalLotteryId,
+                    kinopoisk_id: winner.kinopoisk_id || null,
+                    name: winner.name,
+                    year: winner.year,
+                    poster: winner.poster,
+                    description: winner.description,
+                    rating_kp: winner.rating_kp,
+                    genres: winner.genres,
+                    countries: winner.countries,
+                });
+            });
+        }
+    };
+
+    const renderLotteryDetails = (data) => {
+        renderParticipantsList(data.movies || [], data.result ? data.result.name : null);
+        if (data.result) {
+            renderWinnerCard(data.result);
+        } else {
+            if (modalParticipantsContainer) {
+                modalParticipantsContainer.style.display = 'none';
+            }
+            renderWaitingState(data);
+        }
+    };
+
+    const fetchLotteryDetails = async (lotteryId) => {
+        const response = await fetch(`/api/result/${lotteryId}`);
+        if (!response.ok) throw new Error('Ошибка сети');
+        const data = await response.json();
+        if (data.error) throw new Error(data.error);
+        return data;
+    };
+
+    const openModal = async (lotteryId) => {
+        if (!modalOverlay || !modalWinnerInfo) return;
+        currentModalLotteryId = lotteryId;
+        modalOverlay.style.display = 'flex';
+        modalWinnerInfo.innerHTML = '<div class="loader"></div>';
+        if (modalParticipantsContainer) {
+            modalParticipantsContainer.style.display = 'none';
+        }
+        if (modalParticipantsList) {
+            modalParticipantsList.innerHTML = '';
+        }
+
+        try {
+            const data = await fetchLotteryDetails(lotteryId);
+            renderLotteryDetails(data);
+            if (data.result) {
+                refreshCardActions(lotteryId, data.result);
+            }
+        } catch (error) {
+            modalWinnerInfo.innerHTML = `<p class="error-message">Не удалось загрузить детали: ${escapeHtml(error.message)}</p>`;
+        }
+    };
+
+    const handleSearchClick = (movieName, movieYear) => {
+        if (!movieName) return;
+        const parts = [movieName.trim()];
+        if (movieYear && movieYear.trim()) {
+            parts.push(`(${movieYear.trim()})`);
+        }
+        const query = encodeURIComponent(parts.join(' '));
+        window.open(`https://rutracker.org/forum/tracker.php?nm=${query}`, '_blank');
+    };
+
+    const handleDownloadClick = async (kinopoiskId, movieName, lotteryId) => {
+        if (!kinopoiskId) {
+            alert('Сначала добавьте magnet-ссылку для этого фильма.');
+            openModal(lotteryId);
+            return;
+        }
+        registerDownload(lotteryId, movieName, kinopoiskId);
+        try {
+            const response = await fetch(`/api/start-download/${kinopoiskId}`, { method: 'POST' });
+            const data = await response.json();
+            if (data.success) {
+                startTorrentStatusPolling(lotteryId, movieName, kinopoiskId, { skipRegister: true });
+            } else {
+                alert(`Ошибка: ${data.message}`);
+                removeDownload(lotteryId);
+            }
+        } catch (error) {
+            console.error('Ошибка при запуске скачивания:', error);
+            alert('Произошла критическая ошибка.');
+            removeDownload(lotteryId);
+        }
+    };
+
+    const collectWaitingCards = (map) => {
+        if (!gallery) return;
+        map.clear();
+        gallery.querySelectorAll('.waiting-card').forEach((card) => {
+            const lotteryId = card.dataset.lotteryId;
+            if (lotteryId) {
+                map.set(lotteryId, card);
+            }
+        });
+    };
+
+    const createCompletedCard = (lotteryId, winner, createdAtIso) => {
+        const item = document.createElement('div');
+        item.className = 'gallery-item';
+        item.dataset.lotteryId = lotteryId;
+        item.dataset.kinopoiskId = winner.kinopoisk_id || '';
+        item.dataset.movieName = winner.name || '';
+        item.dataset.movieYear = winner.year || '';
+        item.dataset.moviePoster = winner.poster || '';
+        item.dataset.movieDescription = winner.description || '';
+        item.dataset.movieRating = winner.rating_kp != null ? winner.rating_kp : '';
+        item.dataset.movieGenres = winner.genres || '';
+        item.dataset.movieCountries = winner.countries || '';
+
+        const actionButtonHtml = winner.has_magnet
+            ? '<button class="action-button download-button" title="Скачать фильм">&#x2913;</button>'
+            : '<button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>';
+
+        item.innerHTML = `
+            <div class="action-buttons">
+                ${actionButtonHtml}
+                <button class="action-button library-button" title="Добавить в библиотеку">&#128218;</button>
+                <button class="action-button-delete delete-button" title="Удалить лотерею">&times;</button>
+            </div>
+            <div class="date-badge" data-date="${escapeAttr(createdAtIso)}"></div>
+            <img src="${escapeAttr(winner.poster || placeholderPoster)}" alt="${escapeHtml(winner.name)}">
+        `;
+
+        return item;
+    };
+
+    const pollWaitingCards = (map) => async () => {
+        if (!map.size) return;
+
+        const tasks = Array.from(map.entries()).map(async ([lotteryId, cardElement]) => {
+            try {
+                const data = await fetchLotteryDetails(lotteryId);
+                if (data.result) {
+                    const newCard = createCompletedCard(lotteryId, data.result, data.createdAt);
+                    cardElement.replaceWith(newCard);
+                    refreshCardActions(lotteryId, data.result);
+                    map.delete(lotteryId);
+                    formatDateBadges();
+                } else if (modalOverlay && modalOverlay.style.display === 'flex' && currentModalLotteryId === lotteryId) {
+                    renderWaitingState(data);
+                }
+            } catch (error) {
+                console.error('Не удалось обновить лотерею', lotteryId, error);
+            }
+        });
+
+        await Promise.all(tasks);
+    };
+
     if (gallery) {
-        gallery.addEventListener('click', (e) => {
-            const galleryItem = e.target.closest('.gallery-item');
+        gallery.addEventListener('click', (event) => {
+            const galleryItem = event.target.closest('.gallery-item');
             if (!galleryItem) return;
 
             const { lotteryId, kinopoiskId, movieName, movieYear } = galleryItem.dataset;
-            const isDownloadButton = e.target.classList.contains('download-button');
-            const isSearchButton = e.target.classList.contains('search-button');
-            const isDeleteButton = e.target.classList.contains('delete-button');
-            const isLibraryButton = e.target.classList.contains('library-button');
-
-            e.stopPropagation();
+            const isDownloadButton = event.target.classList.contains('download-button');
+            const isSearchButton = event.target.classList.contains('search-button');
+            const isDeleteButton = event.target.classList.contains('delete-button');
+            const isLibraryButton = event.target.classList.contains('library-button');
 
             if (isDownloadButton) {
+                event.stopPropagation();
                 handleDownloadClick(kinopoiskId, movieName, lotteryId);
-            } else if (isSearchButton) {
-                handleSearchClick(movieName, movieYear);
-            } else if (isDeleteButton) {
-                handleDeleteLottery(lotteryId, galleryItem);
-            } else if (isLibraryButton) {
-                addMovieToLibrary(buildLibraryPayloadFromCard(galleryItem));
-            } else {
-                openModal(lotteryId);
+                return;
             }
+
+            if (isSearchButton) {
+                event.stopPropagation();
+                handleSearchClick(movieName, movieYear);
+                return;
+            }
+
+            if (isDeleteButton) {
+                event.stopPropagation();
+                handleDeleteLottery(lotteryId, galleryItem);
+                return;
+            }
+
+            if (isLibraryButton) {
+                event.stopPropagation();
+                addMovieToLibrary(buildLibraryPayloadFromCard(galleryItem));
+                return;
+            }
+
+            openModal(lotteryId);
         });
     }
 
@@ -424,84 +778,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (closeButton) closeButton.addEventListener('click', closeModal);
     if (modalOverlay) {
-        modalOverlay.addEventListener('click', (e) => {
-            if (e.target === modalOverlay) closeModal();
+        modalOverlay.addEventListener('click', (event) => {
+            if (event.target === modalOverlay) closeModal();
         });
     }
 
-    // --- АВТОМАТИЧЕСКОЕ ОБНОВЛЕНИЕ ОЖИДАЮЩИХ ЛОТЕРЕЙ ---
+    if (widgetHeader) {
+        widgetHeader.addEventListener('click', () => {
+            widget.classList.toggle('minimized');
+        });
+    }
+
+    if (widgetToggleBtn) {
+        widgetToggleBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            widget.classList.toggle('minimized');
+        });
+    }
 
     const waitingCards = new Map();
-    let waitingIntervalId = null;
-    const collectWaitingCards = () => {
-        document.querySelectorAll('.waiting-card').forEach((card) => {
-            const lotteryId = card.dataset.lotteryId;
-            if (lotteryId) {
-                waitingCards.set(lotteryId, card);
-            }
-        });
-    };
+    collectWaitingCards(waitingCards);
 
-    const createCompletedCard = (lotteryId, winner, createdAt) => {
-        const item = document.createElement('div');
-        item.className = 'gallery-item';
-        item.dataset.lotteryId = lotteryId;
-        item.dataset.kinopoiskId = winner.kinopoisk_id || '';
-        item.dataset.movieName = winner.name || '';
-        item.dataset.movieYear = winner.year || '';
-
-
-        const actionButton = winner.has_magnet
-            ? '<button class="action-button download-button" title="Скачать фильм">&#x2913;</button>'
-            : '<button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>';
-
-        item.innerHTML = `
-            <div class="action-buttons">
-                ${actionButton}
-
-
-        return item;
-    };
-
-    const pollWaitingCards = async () => {
-        if (!waitingCards.size) {
-            if (waitingIntervalId) {
-                clearInterval(waitingIntervalId);
-                waitingIntervalId = null;
-            }
-            return;
-        }
-
-        const checkCard = async (lotteryId, cardElement) => {
-            try {
-                const response = await fetch(`/api/result/${lotteryId}`);
-                if (!response.ok) return;
-                const data = await response.json();
-                if (data.result) {
-                    const newCard = createCompletedCard(lotteryId, data.result, data.createdAt);
-                    cardElement.replaceWith(newCard);
-                    waitingCards.delete(lotteryId);
-                }
-            } catch (error) {
-                console.error('Не удалось обновить лотерею', lotteryId, error);
-            }
-        };
-
-        await Promise.all(Array.from(waitingCards.entries()).map(([lotteryId, card]) => checkCard(lotteryId, card)));
-
-        if (!waitingCards.size && waitingIntervalId) {
-            clearInterval(waitingIntervalId);
-            waitingIntervalId = null;
-        }
-    };
-
-    collectWaitingCards();
     if (waitingCards.size) {
-        pollWaitingCards();
-        waitingIntervalId = setInterval(pollWaitingCards, 5000);
+        const poller = pollWaitingCards(waitingCards);
+        poller();
+        const waitingIntervalId = setInterval(() => {
+            if (!waitingCards.size) {
+                clearInterval(waitingIntervalId);
+                return;
+            }
+            poller();
+        }, 5000);
     }
 
     initializeStoredDownloads();
     ensureWidgetState();
-
+    formatDateBadges();
 });

--- a/static/js/library.js
+++ b/static/js/library.js
@@ -1,7 +1,475 @@
 // static/js/library.js
 
 document.addEventListener('DOMContentLoaded', () => {
+    const gallery = document.querySelector('.library-gallery');
+    const modalOverlay = document.getElementById('library-modal');
+    const modalBody = document.getElementById('library-modal-body');
+    const closeButton = modalOverlay ? modalOverlay.querySelector('.close-button') : null;
+    const emptyMessage = document.querySelector('.library-empty-message');
 
+    const widget = document.getElementById('torrent-status-widget');
+    const widgetHeader = widget ? widget.querySelector('.widget-header') : null;
+    const widgetToggleBtn = widget ? widget.querySelector('#widget-toggle-btn') : null;
+    const widgetDownloadsContainer = widget ? widget.querySelector('#widget-downloads') : null;
+    const widgetEmptyText = widget ? widget.querySelector('.widget-empty') : null;
+
+    const placeholderPoster = 'https://via.placeholder.com/200x300.png?text=No+Image';
+    const ACTIVE_DOWNLOADS_KEY = 'libraryActiveDownloads';
+
+    const pollIntervals = new Map();
+    const activeDownloads = new Map();
+
+    let currentModalCard = null;
+    let currentModalResourceKey = null;
+
+    const escapeHtml = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    };
+
+    const escapeAttr = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;');
+    };
+
+    const formatDateBadges = () => {
+        if (!gallery) return;
+        gallery.querySelectorAll('.date-badge').forEach((badge) => {
+            const iso = badge.dataset.date;
+            if (!iso) return;
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+            const day = String(date.getDate()).padStart(2, '0');
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const year = date.getFullYear();
+            badge.textContent = `${day}.${month}.${year}`;
+        });
+    };
+
+    const ensureEmptyState = () => {
+        if (!emptyMessage) return;
+        const hasItems = gallery && gallery.querySelector('.gallery-item');
+        emptyMessage.style.display = hasItems ? 'none' : 'block';
+    };
+
+    const determineResourceKey = (card) => {
+        if (!card) return null;
+        const kinopoiskId = card.dataset.kinopoiskId;
+        return kinopoiskId ? `library-${kinopoiskId}` : null;
+    };
+
+    const closeModal = () => {
+        if (!modalOverlay) return;
+        modalOverlay.style.display = 'none';
+        document.body.classList.remove('no-scroll');
+        currentModalCard = null;
+        currentModalResourceKey = null;
+    };
+
+    const saveActiveDownloads = () => {
+        if (!widget) return;
+        try {
+            const payload = Array.from(activeDownloads.values()).map((entry) => ({
+                resourceKey: entry.resourceKey,
+                movieName: entry.movieName,
+                kinopoiskId: entry.kinopoiskId,
+            }));
+            localStorage.setItem(ACTIVE_DOWNLOADS_KEY, JSON.stringify(payload));
+        } catch (error) {
+            console.warn('Не удалось сохранить активные загрузки:', error);
+        }
+    };
+
+    const loadStoredDownloads = () => {
+        if (!widget) return [];
+        try {
+            const raw = localStorage.getItem(ACTIVE_DOWNLOADS_KEY);
+            if (!raw) return [];
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+            console.warn('Не удалось восстановить активные загрузки:', error);
+            localStorage.removeItem(ACTIVE_DOWNLOADS_KEY);
+            return [];
+        }
+    };
+
+    const ensureWidgetState = () => {
+        if (!widget) return;
+        const hasDownloads = activeDownloads.size > 0;
+        widget.style.display = hasDownloads ? 'block' : 'none';
+        if (widgetEmptyText) {
+            widgetEmptyText.style.display = hasDownloads ? 'none' : 'block';
+        }
+        if (widgetDownloadsContainer) {
+            widgetDownloadsContainer.style.display = hasDownloads ? 'block' : 'none';
+        }
+        if (hasDownloads) {
+            widget.classList.remove('minimized');
+        }
+    };
+
+    const getOrCreateDownloadElement = (resourceKey) => {
+        if (!widgetDownloadsContainer) return null;
+        let item = widgetDownloadsContainer.querySelector(`[data-resource-key="${resourceKey}"]`);
+        if (!item) {
+            item = document.createElement('div');
+            item.className = 'widget-download';
+            item.dataset.resourceKey = resourceKey;
+            item.innerHTML = `
+                <h5 class="widget-download-title"></h5>
+                <div class="progress-bar-container">
+                    <div class="progress-bar"></div>
+                </div>
+                <div class="widget-stats">
+                    <span class="progress-text">0%</span>
+                    <span class="speed-text">0.00 МБ/с</span>
+                    <span class="eta-text">--:--</span>
+                </div>
+                <div class="widget-stats-bottom">
+                    <span class="peers-text">Сиды: 0 / Пиры: 0</span>
+                </div>
+            `;
+            widgetDownloadsContainer.appendChild(item);
+        }
+        return item;
+    };
+
+    const registerDownload = (resourceKey, movieName, kinopoiskId, { skipSave = false } = {}) => {
+        if (!widget || !resourceKey) return null;
+        const existing = activeDownloads.get(resourceKey) || {};
+        const updated = {
+            resourceKey,
+            movieName: movieName || existing.movieName || 'Загрузка...',
+            kinopoiskId: kinopoiskId || existing.kinopoiskId || null,
+        };
+        activeDownloads.set(resourceKey, updated);
+
+        const element = getOrCreateDownloadElement(resourceKey);
+        if (element) {
+            const title = element.querySelector('.widget-download-title');
+            if (title) {
+                title.textContent = `Загрузка: ${updated.movieName}`;
+            }
+        }
+
+        ensureWidgetState();
+        if (!skipSave) saveActiveDownloads();
+        return updated;
+    };
+
+    const removeDownload = (resourceKey) => {
+        if (pollIntervals.has(resourceKey)) {
+            clearInterval(pollIntervals.get(resourceKey));
+            pollIntervals.delete(resourceKey);
+        }
+        if (activeDownloads.has(resourceKey)) {
+            activeDownloads.delete(resourceKey);
+            saveActiveDownloads();
+        }
+        if (widgetDownloadsContainer) {
+            const element = widgetDownloadsContainer.querySelector(`[data-resource-key="${resourceKey}"]`);
+            if (element) {
+                element.remove();
+            }
+        }
+        ensureWidgetState();
+    };
+
+    const updateModalStatus = (resourceKey, data) => {
+        if (!modalBody || currentModalResourceKey !== resourceKey) return;
+        const statusBlock = modalBody.querySelector('[data-status-block]');
+        if (!statusBlock) return;
+
+        const statusTextEl = statusBlock.querySelector('[data-status-text]');
+        const progressTextEl = statusBlock.querySelector('[data-progress-text]');
+        const speedTextEl = statusBlock.querySelector('[data-speed-text]');
+        const etaTextEl = statusBlock.querySelector('[data-eta-text]');
+        const peersTextEl = statusBlock.querySelector('[data-peers-text]');
+        const barEl = statusBlock.querySelector('[data-progress-bar]');
+
+        const setIdle = (message) => {
+            if (statusTextEl) statusTextEl.textContent = message || 'Нет активной загрузки';
+            if (progressTextEl) progressTextEl.textContent = '0%';
+            if (speedTextEl) speedTextEl.textContent = '0.00 МБ/с';
+            if (etaTextEl) etaTextEl.textContent = '--:--';
+            if (peersTextEl) peersTextEl.textContent = 'Сиды: 0 / Пиры: 0';
+            if (barEl) barEl.style.width = '0%';
+        };
+
+        if (!data || data.status === 'not_found') {
+            setIdle('Нет активной загрузки');
+            return;
+        }
+
+        if (data.status === 'error') {
+            setIdle('Ошибка загрузки');
+            if (peersTextEl) peersTextEl.textContent = data.message || 'qBittorrent недоступен';
+            return;
+        }
+
+        const progressValue = Number.parseFloat(data.progress) || 0;
+        if (statusTextEl) statusTextEl.textContent = data.status ? data.status.toString() : 'Загрузка';
+        if (progressTextEl) progressTextEl.textContent = `${progressValue.toFixed(0)}%`;
+        if (speedTextEl) {
+            const speedValue = Number.parseFloat(data.speed);
+            const formattedSpeed = Number.isFinite(speedValue) ? `${speedValue.toFixed(2)} МБ/с` : '0.00 МБ/с';
+            speedTextEl.textContent = formattedSpeed;
+        }
+        if (etaTextEl) etaTextEl.textContent = data.eta || '--:--';
+        if (peersTextEl) {
+            const seeds = data.seeds ?? 0;
+            const peers = data.peers ?? 0;
+            peersTextEl.textContent = `Сиды: ${seeds} / Пиры: ${peers}`;
+        }
+        if (barEl) {
+            const clamped = Math.min(100, Math.max(0, progressValue));
+            barEl.style.width = `${clamped}%`;
+        }
+    };
+
+    const updateDownloadView = (resourceKey, data) => {
+        if (!widgetDownloadsContainer) return;
+        const element = widgetDownloadsContainer.querySelector(`[data-resource-key="${resourceKey}"]`);
+        if (!element) return;
+
+        const title = element.querySelector('.widget-download-title');
+        const bar = element.querySelector('.progress-bar');
+        const progressText = element.querySelector('.progress-text');
+        const speedText = element.querySelector('.speed-text');
+        const etaText = element.querySelector('.eta-text');
+        const peersText = element.querySelector('.peers-text');
+
+        if (data.name && title) {
+            title.textContent = `Загрузка: ${data.name}`;
+        }
+
+        if (data.status === 'error') {
+            if (progressText) progressText.textContent = 'Ошибка';
+            if (speedText) speedText.textContent = '-';
+            if (etaText) etaText.textContent = '-';
+            if (peersText) peersText.textContent = data.message || '';
+            if (bar) bar.style.width = '0%';
+            updateModalStatus(resourceKey, data);
+            return;
+        }
+
+        if (data.status === 'not_found') {
+            if (progressText) progressText.textContent = 'Ожидание...';
+            if (speedText) speedText.textContent = '0.00 МБ/с';
+            if (etaText) etaText.textContent = '--:--';
+            if (peersText) peersText.textContent = 'Торрент не найден';
+            if (bar) bar.style.width = '0%';
+            updateModalStatus(resourceKey, data);
+            return;
+        }
+
+        const progressValue = Number.parseFloat(data.progress) || 0;
+        if (bar) bar.style.width = `${Math.min(100, Math.max(0, progressValue))}%`;
+        if (progressText) progressText.textContent = `${progressValue.toFixed(0)}%`;
+        if (speedText) {
+            const speedValue = Number.parseFloat(data.speed);
+            speedText.textContent = Number.isFinite(speedValue) ? `${speedValue.toFixed(2)} МБ/с` : '0.00 МБ/с';
+        }
+        if (etaText) etaText.textContent = data.eta || '--:--';
+        if (peersText) peersText.textContent = `Сиды: ${data.seeds ?? 0} / Пиры: ${data.peers ?? 0}`;
+
+        updateModalStatus(resourceKey, data);
+    };
+
+    const markDownloadCompleted = (resourceKey) => {
+        if (!widgetDownloadsContainer) return;
+        const element = widgetDownloadsContainer.querySelector(`[data-resource-key="${resourceKey}"]`);
+        if (!element) return;
+
+        const bar = element.querySelector('.progress-bar');
+        const progressText = element.querySelector('.progress-text');
+        const speedText = element.querySelector('.speed-text');
+        const etaText = element.querySelector('.eta-text');
+        const peersText = element.querySelector('.peers-text');
+
+        if (bar) bar.style.width = '100%';
+        if (progressText) progressText.textContent = '100%';
+        if (speedText) speedText.textContent = 'Готово';
+        if (etaText) etaText.textContent = '--';
+        if (peersText) peersText.textContent = 'Раздача';
+
+        updateModalStatus(resourceKey, {
+            status: 'completed',
+            progress: 100,
+            speed: '0.00',
+            eta: '--:--',
+            seeds: 0,
+            peers: 0,
+        });
+
+        setTimeout(() => removeDownload(resourceKey), 5000);
+    };
+
+    const startTorrentStatusPolling = (resourceKey, movieName, kinopoiskId, { skipRegister = false } = {}) => {
+        if (!resourceKey) return;
+        if (!skipRegister) {
+            registerDownload(resourceKey, movieName, kinopoiskId);
+        }
+
+        if (pollIntervals.has(resourceKey)) {
+            clearInterval(pollIntervals.get(resourceKey));
+        }
+
+        const poll = async () => {
+            try {
+                const response = await fetch(`/api/torrent-status/${encodeURIComponent(resourceKey)}`);
+                if (!response.ok) {
+                    throw new Error('Сервер вернул ошибку статуса');
+                }
+                const data = await response.json();
+
+                if (data.status === 'error') {
+                    updateDownloadView(resourceKey, data);
+                    if (pollIntervals.has(resourceKey)) {
+                        clearInterval(pollIntervals.get(resourceKey));
+                        pollIntervals.delete(resourceKey);
+                    }
+                    return;
+                }
+
+                updateDownloadView(resourceKey, data);
+
+                const progressValue = Number.parseFloat(data.progress) || 0;
+                const statusText = (data.status || '').toLowerCase();
+                const isCompleted = progressValue >= 100 || statusText.includes('seeding') || statusText.includes('completed');
+
+                if (isCompleted) {
+                    if (pollIntervals.has(resourceKey)) {
+                        clearInterval(pollIntervals.get(resourceKey));
+                        pollIntervals.delete(resourceKey);
+                    }
+                    markDownloadCompleted(resourceKey);
+                }
+            } catch (error) {
+                console.error('Ошибка при опросе статуса торрента:', error);
+                updateDownloadView(resourceKey, { status: 'error', message: 'Нет связи с qBittorrent' });
+                if (pollIntervals.has(resourceKey)) {
+                    clearInterval(pollIntervals.get(resourceKey));
+                    pollIntervals.delete(resourceKey);
+                }
+            }
+        };
+
+        poll();
+        const intervalId = setInterval(poll, 3000);
+        pollIntervals.set(resourceKey, intervalId);
+    };
+
+    const initializeStoredDownloads = () => {
+        if (!widget) return;
+        const stored = loadStoredDownloads();
+        stored.forEach((entry) => {
+            if (!entry || !entry.resourceKey) return;
+            startTorrentStatusPolling(entry.resourceKey, entry.movieName, entry.kinopoiskId);
+        });
+    };
+
+    const refreshCardActions = (card) => {
+        if (!card) return;
+        const buttons = card.querySelector('.action-buttons');
+        if (!buttons) return;
+
+        const hasMagnet = card.dataset.hasMagnet === 'true';
+        let downloadBtn = buttons.querySelector('.download-button');
+
+        if (hasMagnet) {
+            if (!downloadBtn) {
+                downloadBtn = document.createElement('button');
+                downloadBtn.className = 'action-button download-button';
+                downloadBtn.title = 'Скачать торрент';
+                downloadBtn.innerHTML = '&#x2913;';
+                buttons.insertBefore(downloadBtn, buttons.firstChild);
+            }
+        } else if (downloadBtn) {
+            downloadBtn.remove();
+        }
+    };
+
+    const updateModalMagnetState = (card) => {
+        if (!modalBody || currentModalCard !== card) return;
+        const magnetInput = modalBody.querySelector('#magnet-input');
+        const deleteBtn = modalBody.querySelector('.delete-magnet-btn');
+        const downloadBtn = modalBody.querySelector('.modal-download-btn');
+        const hasMagnet = card.dataset.hasMagnet === 'true';
+
+        if (magnetInput) {
+            magnetInput.value = card.dataset.magnetLink || '';
+        }
+        if (deleteBtn) {
+            deleteBtn.style.display = hasMagnet ? 'inline-flex' : 'none';
+        }
+        if (downloadBtn) {
+            downloadBtn.disabled = !hasMagnet || !card.dataset.kinopoiskId;
+        }
+    };
+
+    const handleSaveMagnet = async (card, magnetLink) => {
+        if (!card) return;
+        const kinopoiskId = card.dataset.kinopoiskId;
+        if (!kinopoiskId) {
+            alert('Для этого фильма отсутствует ID Кинопоиска. Магнит-ссылка не может быть сохранена.');
+            return;
+        }
+        try {
+            const response = await fetch('/api/movie-magnet', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ kinopoisk_id: Number(kinopoiskId), magnet_link: magnetLink }),
+            });
+            const data = await response.json();
+            alert(data.message);
+            if (!response.ok || !data.success) {
+                return;
+            }
+            card.dataset.hasMagnet = data.has_magnet ? 'true' : 'false';
+            card.dataset.magnetLink = data.magnet_link || '';
+            refreshCardActions(card);
+            updateModalMagnetState(card);
+        } catch (error) {
+            console.error('Ошибка при сохранении magnet-ссылки:', error);
+            alert('Произошла ошибка при сохранении magnet-ссылки.');
+        }
+    };
+
+    const handleSearch = (name, year) => {
+        if (!name) return;
+        const parts = [name.trim()];
+        if (year && year.trim()) {
+            parts.push(`(${year.trim()})`);
+        }
+        const query = encodeURIComponent(parts.join(' '));
+        window.open(`https://rutracker.org/forum/tracker.php?nm=${query}`, '_blank');
+    };
+
+    const removeCardFromDom = (card) => {
+        if (!card) return;
+        card.classList.add('is-deleting');
+        setTimeout(() => {
+            card.remove();
+            ensureEmptyState();
+        }, 300);
+    };
+
+    const handleDelete = async (card) => {
+        if (!card) return;
+        const movieId = card.dataset.movieId;
         if (!movieId) return;
 
         if (!confirm('Удалить фильм из библиотеки?')) {
@@ -15,6 +483,224 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(data.message || 'Не удалось удалить фильм.');
             }
 
+            closeModal();
+            removeCardFromDom(card);
+        } catch (error) {
+            alert(error.message);
         }
-    });
+    };
+
+    const handleDownload = async (card) => {
+        if (!card) return;
+        const kinopoiskId = card.dataset.kinopoiskId;
+        const movieName = card.dataset.movieName;
+        const hasMagnet = card.dataset.hasMagnet === 'true';
+        if (!kinopoiskId || !hasMagnet) {
+            alert('Сначала добавьте magnet-ссылку для этого фильма.');
+            renderModal(card);
+            return;
+        }
+
+        const resourceKey = determineResourceKey(card);
+        registerDownload(resourceKey, movieName, kinopoiskId);
+
+        try {
+            const response = await fetch(`/api/start-download/${kinopoiskId}?source=library`, { method: 'POST' });
+            const data = await response.json();
+            if (data.success) {
+                startTorrentStatusPolling(resourceKey, movieName, kinopoiskId, { skipRegister: true });
+            } else {
+                alert(`Ошибка: ${data.message}`);
+                removeDownload(resourceKey);
+            }
+        } catch (error) {
+            console.error('Ошибка при запуске скачивания:', error);
+            alert('Произошла критическая ошибка.');
+            removeDownload(resourceKey);
+        }
+    };
+
+    const fetchStatusOnce = async (resourceKey) => {
+        if (!resourceKey) return;
+        try {
+            const response = await fetch(`/api/torrent-status/${encodeURIComponent(resourceKey)}`);
+            if (!response.ok) return;
+            const data = await response.json();
+            updateModalStatus(resourceKey, data);
+        } catch (error) {
+            console.warn('Не удалось получить статус загрузки:', error);
+        }
+    };
+
+    const renderModal = (card) => {
+        if (!modalOverlay || !modalBody || !card) return;
+        currentModalCard = card;
+        currentModalResourceKey = determineResourceKey(card);
+
+        const rawMovieName = card.dataset.movieName || 'Неизвестный фильм';
+        const rawMovieYear = card.dataset.movieYear || '';
+        const rawMoviePoster = card.dataset.moviePoster || '';
+        const rawMovieDescription = card.dataset.movieDescription || '';
+        const rawMovieGenres = card.dataset.movieGenres || '';
+        const rawMovieCountries = card.dataset.movieCountries || '';
+        const rawMovieRating = card.dataset.movieRating || '';
+        const rawMagnetLink = card.dataset.magnetLink || '';
+
+        const hasMagnet = card.dataset.hasMagnet === 'true';
+        const kinopoiskId = card.dataset.kinopoiskId;
+        const ratingValue = parseFloat(rawMovieRating);
+        let ratingBadge = '';
+        if (!Number.isNaN(ratingValue)) {
+            const ratingClass = ratingValue >= 7 ? 'rating-high' : ratingValue >= 5 ? 'rating-medium' : 'rating-low';
+            ratingBadge = `<div class="rating-badge ${ratingClass}">${ratingValue.toFixed(1)}</div>`;
+        }
+
+        const posterSrc = rawMoviePoster || placeholderPoster;
+        const safeMovieName = escapeHtml(rawMovieName);
+        const safeMovieYear = escapeHtml(rawMovieYear);
+        const safeGenres = escapeHtml(rawMovieGenres || 'н/д');
+        const safeCountries = escapeHtml(rawMovieCountries || 'н/д');
+        const safeDescription = escapeHtml(rawMovieDescription || 'Описание отсутствует.');
+        const safeMagnetValue = escapeAttr(rawMagnetLink);
+
+        const magnetSection = kinopoiskId
+            ? `
+                <div class="magnet-form">
+                    <label for="magnet-input">Magnet-ссылка:</label>
+                    <input type="text" id="magnet-input" value="${safeMagnetValue}" placeholder="Вставьте magnet-ссылку и нажмите Сохранить...">
+                    <div class="magnet-actions">
+                        <button class="action-button save-magnet-btn">Сохранить</button>
+                        <button class="action-button-delete delete-magnet-btn" style="display: ${hasMagnet ? 'inline-flex' : 'none'};">Удалить ссылку</button>
+                    </div>
+                </div>
+            `
+            : '<p class="magnet-hint">Для сохранения magnet-ссылки требуется ID фильма на Кинопоиске.</p>';
+
+        modalBody.innerHTML = `
+            <div class="winner-card">
+                <div class="winner-poster">
+                    <img src="${escapeAttr(posterSrc)}" alt="Постер ${safeMovieName}">
+                    ${ratingBadge}
+                </div>
+                <div class="winner-details">
+                    <h2>${safeMovieName}${safeMovieYear ? ` (${safeMovieYear})` : ''}</h2>
+                    <p class="meta-info">${safeGenres} / ${safeCountries}</p>
+                    <p class="description">${safeDescription}</p>
+                    ${magnetSection}
+                    <div class="library-modal-actions">
+                        <button class="secondary-button modal-download-btn" ${!hasMagnet || !kinopoiskId ? 'disabled' : ''}>Скачать торрент</button>
+                        <button class="secondary-button modal-search-btn">Искать торрент</button>
+                        <button class="danger-button modal-delete-btn">Удалить из библиотеки</button>
+                    </div>
+                    <div class="download-status" data-status-block>
+                        <div class="status-progress-track">
+                            <div class="status-progress-bar" data-progress-bar style="width: 0%;"></div>
+                        </div>
+                        <div class="status-grid">
+                            <div><span class="status-label">Статус:</span> <span data-status-text>Нет активной загрузки</span></div>
+                            <div><span class="status-label">Прогресс:</span> <span data-progress-text>0%</span></div>
+                            <div><span class="status-label">Скорость:</span> <span data-speed-text>0.00 МБ/с</span></div>
+                            <div><span class="status-label">Оставшееся время:</span> <span data-eta-text>--:--</span></div>
+                            <div><span class="status-label">Сиды / Пиры:</span> <span data-peers-text>Сиды: 0 / Пиры: 0</span></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        modalOverlay.style.display = 'flex';
+        document.body.classList.add('no-scroll');
+
+        const searchBtn = modalBody.querySelector('.modal-search-btn');
+        if (searchBtn) {
+            searchBtn.addEventListener('click', () => handleSearch(rawMovieName, rawMovieYear));
+        }
+
+        const deleteBtn = modalBody.querySelector('.modal-delete-btn');
+        if (deleteBtn) {
+            deleteBtn.addEventListener('click', () => handleDelete(card));
+        }
+
+        const downloadBtn = modalBody.querySelector('.modal-download-btn');
+        if (downloadBtn) {
+            downloadBtn.addEventListener('click', () => handleDownload(card));
+        }
+
+        const saveBtn = modalBody.querySelector('.save-magnet-btn');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', () => {
+                const input = modalBody.querySelector('#magnet-input');
+                handleSaveMagnet(card, input ? input.value.trim() : '');
+            });
+        }
+
+        const deleteMagnetBtn = modalBody.querySelector('.delete-magnet-btn');
+        if (deleteMagnetBtn) {
+            deleteMagnetBtn.addEventListener('click', () => {
+                if (confirm('Удалить сохраненную magnet-ссылку?')) {
+                    handleSaveMagnet(card, '');
+                }
+            });
+        }
+
+        if (currentModalResourceKey) {
+            fetchStatusOnce(currentModalResourceKey);
+        }
+    };
+
+    if (gallery) {
+        gallery.addEventListener('click', (event) => {
+            const card = event.target.closest('.gallery-item');
+            if (!card) return;
+
+            if (event.target.classList.contains('download-button')) {
+                event.stopPropagation();
+                handleDownload(card);
+                return;
+            }
+
+            if (event.target.classList.contains('search-button')) {
+                event.stopPropagation();
+                handleSearch(card.dataset.movieName, card.dataset.movieYear);
+                return;
+            }
+
+            if (event.target.classList.contains('delete-button')) {
+                event.stopPropagation();
+                handleDelete(card);
+                return;
+            }
+
+            renderModal(card);
+        });
+    }
+
+    if (closeButton) {
+        closeButton.addEventListener('click', closeModal);
+    }
+
+    if (modalOverlay) {
+        modalOverlay.addEventListener('click', (event) => {
+            if (event.target === modalOverlay) {
+                closeModal();
+            }
+        });
+    }
+
+    if (widgetHeader) {
+        widgetHeader.addEventListener('click', () => {
+            widget.classList.toggle('minimized');
+        });
+    }
+
+    if (widgetToggleBtn) {
+        widgetToggleBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            widget.classList.toggle('minimized');
+        });
+    }
+
+    formatDateBadges();
+    ensureEmptyState();
+    initializeStoredDownloads();
 });

--- a/templates/library.html
+++ b/templates/library.html
@@ -20,14 +20,58 @@
         </div>
     </header>
 
-
+    <div class="history-gallery library-gallery">
+        {% if library_movies %}
+            {% for movie in library_movies %}
+                {% set identifier = identifiers.get(movie.kinopoisk_id) if movie.kinopoisk_id else None %}
+                <div
+                    class="gallery-item library-card"
+                    data-movie-id="{{ movie.id }}"
+                    data-kinopoisk-id="{{ movie.kinopoisk_id or '' }}"
+                    data-movie-name="{{ movie.name|e }}"
+                    data-movie-year="{{ movie.year or '' }}"
+                    data-movie-poster="{{ (movie.poster or '')|e }}"
+                    data-movie-description="{{ (movie.description|default('', true)|replace('\n', ' '))|e }}"
+                    data-movie-rating="{{ '%.1f'|format(movie.rating_kp) if movie.rating_kp is not none else '' }}"
+                    data-movie-genres="{{ (movie.genres|default('', true))|e }}"
+                    data-movie-countries="{{ (movie.countries|default('', true))|e }}"
+                    data-added-at="{{ movie.added_at.isoformat() }}"
+                    data-has-magnet="{{ 'true' if identifier and identifier.magnet_link else 'false' }}"
+                    data-magnet-link="{{ identifier.magnet_link if identifier and identifier.magnet_link else '' }}"
+                >
+                    <div class="action-buttons">
+                        {% if identifier and identifier.magnet_link %}
+                            <button class="action-button download-button" title="Скачать торрент">&#x2913;</button>
+                        {% endif %}
+                        <button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>
+                        <button class="action-button-delete delete-button" title="Удалить из библиотеки">&times;</button>
+                    </div>
+                    <img src="{{ movie.poster or 'https://via.placeholder.com/200x300.png?text=No+Image' }}" alt="{{ movie.name|e }}">
+                    <div class="date-badge" data-date="{{ movie.added_at.isoformat() }}"></div>
                 </div>
             {% endfor %}
-        {% else %}
-            <p class="no-history">В библиотеке пока нет фильмов.</p>
         {% endif %}
     </div>
 
+    <p class="no-history library-empty-message"{% if library_movies %} style="display: none;"{% endif %}>В библиотеке пока нет фильмов.</p>
+
+    <div id="torrent-status-widget" class="status-widget" style="display: none;">
+        <div class="widget-header">
+            <h4>Статус загрузки</h4>
+            <button id="widget-toggle-btn" class="widget-toggle-btn">&mdash;</button>
+        </div>
+        <div id="widget-body" class="widget-body">
+            <p class="widget-empty">Активных загрузок нет.</p>
+            <div id="widget-downloads"></div>
+        </div>
+    </div>
+
+    <div id="library-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <div id="library-modal-body"></div>
+        </div>
+    </div>
 
     <script src="{{ url_for('static', filename='js/library.js') }}"></script>
     <script>

--- a/tests/test_torrent_status.py
+++ b/tests/test_torrent_status.py
@@ -1,79 +1,3 @@
-<<<<<<< HEAD
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/tests/test_torrent_status.py
-index 0000000000000000000000000000000000000000..0cca09097118b30f3ac01f85541c164faffdea79 100644
---- a//dev/null
-+++ b/tests/test_torrent_status.py
-@@ -0,0 +1,65 @@
-+import importlib
-+import sys
-+from pathlib import Path
-+
-+import pytest
-+
-+
-+class _FakeTorrent:
-+    progress = 0.5
-+    dlspeed = 1024 * 1024  # 1 MiB/s
-+    eta = 120
-+    state = "downloading"
-+    name = "Test Torrent"
-+
-+
-+class _FakeClient:
-+    last_category = None
-+    logged_out = False
-+
-+    def __init__(self, *args, **kwargs):
-+        pass
-+
-+    def auth_log_in(self):
-+        return None
-+
-+    def auth_log_out(self):
-+        _FakeClient.logged_out = True
-+
-+    def torrents_info(self, category=None):
-+        _FakeClient.last_category = category
-+        return [_FakeTorrent()]
-+
-+
-+@pytest.fixture
-+def app_module(monkeypatch):
-+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
-+    project_root = Path(__file__).resolve().parent.parent
-+    if str(project_root) not in sys.path:
-+        sys.path.insert(0, str(project_root))
-+    sys.modules.pop("app", None)
-+    module = importlib.import_module("app")
-+    module.app.config["TESTING"] = True
-+    monkeypatch.setattr(module, "Client", _FakeClient)
-+    _FakeClient.last_category = None
-+    _FakeClient.logged_out = False
-+    yield module
-+
-+
-+def test_get_torrent_status_uses_passed_lottery_id(app_module):
-+    client = app_module.app.test_client()
-+    lottery_id = "abc123"
-+
-+    response = client.get(f"/api/torrent-status/{lottery_id}")
-+
-+    assert response.status_code == 200
-+    payload = response.get_json()
-+    assert payload == {
-+        "status": "downloading",
-+        "progress": 50.0,
-+        "speed_mbps": 1.0,
-+        "eta": "2м",
-+        "name": "Test Torrent",
-+    }
-+    assert _FakeClient.last_category == f"lottery-{lottery_id}"
-+    assert _FakeClient.logged_out is True
- 
-EOF
-)
-=======
 import importlib
 import sys
 from pathlib import Path
@@ -87,6 +11,8 @@ class _FakeTorrent:
     eta = 120
     state = "downloading"
     name = "Test Torrent"
+    num_seeds = 3
+    num_leechs = 1
 
 
 class _FakeClient:
@@ -124,19 +50,32 @@ def app_module(monkeypatch):
 
 def test_get_torrent_status_uses_passed_lottery_id(app_module):
     client = app_module.app.test_client()
-    lottery_id = "abc123"
 
-    response = client.get(f"/api/torrent-status/{lottery_id}")
+    response = client.get("/api/torrent-status/abc123")
 
     assert response.status_code == 200
     payload = response.get_json()
     assert payload == {
         "status": "downloading",
-        "progress": 50.0,
-        "speed_mbps": 1.0,
-        "eta": "2м",
+        "progress": "50.0",
+        "speed": "1.00",
         "name": "Test Torrent",
+        "eta": "0ч 2м",
+        "seeds": 3,
+        "peers": 1,
+        "category": "lottery-abc123",
     }
-    assert _FakeClient.last_category == f"lottery-{lottery_id}"
+    assert _FakeClient.last_category == "lottery-abc123"
     assert _FakeClient.logged_out is True
->>>>>>> f80e8a49124308e5ecb61734941beed7a3369c15
+
+
+def test_get_torrent_status_accepts_prefixed_category(app_module):
+    client = app_module.app.test_client()
+
+    response = client.get("/api/torrent-status/library-777")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["category"] == "library-777"
+    assert payload["status"] == "downloading"
+    assert _FakeClient.last_category == "library-777"


### PR DESCRIPTION
## Summary
- expose magnet management, download controls, and a shared status widget on the library page with updated modal logic
- update backend download/status endpoints to support library categories and surface the assigned category in responses
- restyle gallery date badges to numeric stamps and add regression tests for start-download and torrent-status behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf94fcedf08328939e1ad217817d50