### PR TITLE
Add library magnet download controls and update date styling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -317,24 +317,19 @@ button:disabled {
 .gallery-item:hover img { transform: scale(1.05); filter: brightness(1.1); }
 .date-badge {
     position: absolute;
-    top: 48px;
-    right: 8px;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    border-radius: 20px;
-    background-color: rgba(0, 0, 0, 0.7);
-    color: white;
+    bottom: 12px;
+    right: 12px;
+    display: inline-block;
+    color: rgba(248, 249, 250, 0.85);
     font-size: 13px;
     font-weight: 600;
     letter-spacing: 0.3px;
     transition: opacity 0.3s ease;
     pointer-events: none;
     z-index: 2;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
 }
 .gallery-item:hover .date-badge, .waiting-card:hover .date-badge { opacity: 0; }
-.date-badge .calendar-icon { font-size: 15px; }
 .no-history { grid-column: 1 / -1; text-align: center; font-size: 1.2em; color: #adb5bd; padding: 50px; }
 .waiting-card { background-color: #2b2b2b; display: flex; justify-content: center; align-items: center; text-align: center; color: #adb5bd; transition: background-color 0.4s; }
 .waiting-card:hover { background-color: #343a40; }
@@ -342,7 +337,7 @@ button:disabled {
 .waiting-card.is-updating .waiting-content { opacity: 0; }
 .waiting-content .loader-small { border: 3px solid #6c757d; border-top: 3px solid var(--primary-color); border-radius: 50%; width: 30px; height: 30px; animation: spin 1s linear infinite; margin: 0 auto 10px; }
 .waiting-content span { font-weight: 700; }
-.waiting-card .date-badge { top: 12px; }
+.waiting-card .date-badge { bottom: 12px; }
 
 
 

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -291,7 +291,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!gallery) return;
         const formatter = new Intl.DateTimeFormat('ru-RU', {
             day: '2-digit',
-            month: 'long',
+            month: '2-digit',
             year: 'numeric',
         });
 
@@ -300,7 +300,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!iso) return;
             const date = new Date(iso);
             if (Number.isNaN(date.getTime())) return;
-            badge.innerHTML = `<span class="calendar-icon">&#x1F4C5;</span>${formatter.format(date)}`;
+            badge.textContent = formatter.format(date);
         });
     };
 

--- a/templates/library.html
+++ b/templates/library.html
@@ -26,6 +26,7 @@
                 <div
                     class="gallery-item library-card"
                     data-movie-id="{{ movie.id }}"
+                    data-kinopoisk-id="{{ movie.kinopoisk_id or '' }}"
                     data-movie-name="{{ movie.name|e }}"
                     data-movie-year="{{ movie.year or '' }}"
                     data-movie-poster="{{ (movie.poster or '')|e }}"
@@ -34,8 +35,11 @@
                     data-movie-genres="{{ (movie.genres|default('', true))|e }}"
                     data-movie-countries="{{ (movie.countries|default('', true))|e }}"
                     data-added-at="{{ movie.added_at.isoformat() }}"
+                    data-has-magnet="{{ 'true' if movie.has_magnet else 'false' }}"
+                    data-magnet-link="{{ (movie.magnet_link or '')|e }}"
                 >
                     <div class="action-buttons">
+                        <button class="action-button download-button" title="Скачать торрент">&#x2913;</button>
                         <button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>
                         <button class="action-button-delete delete-button" title="Удалить из библиотеки">&times;</button>
                     </div>
@@ -52,6 +56,17 @@
         <div class="modal-content">
             <span class="close-button">&times;</span>
             <div id="library-modal-body"></div>
+        </div>
+    </div>
+
+    <div id="torrent-status-widget" class="status-widget" style="display: none;">
+        <div class="widget-header">
+            <h4>Статус загрузки</h4>
+            <button id="widget-toggle-btn" class="widget-toggle-btn">&mdash;</button>
+        </div>
+        <div id="widget-body" class="widget-body">
+            <p class="widget-empty">Активных загрузок нет.</p>
+            <div id="widget-downloads"></div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- restyle lottery and library date badges to show numeric dates at the bottom without background icons
- enrich the library page with magnet link management, download controls, and a torrent status widget
- extend the Flask backend with library-specific torrent start and status endpoints and expose magnet metadata to templates

## Testing
- pytest *(fails: SyntaxError in tests/test_torrent_status.py because the file contains unfinished patch instructions)*

------
https://chatgpt.com/codex/tasks/task_e_68cfab02c7348328832738e3c6e5da08