### PR TITLE
Refine library and history action icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -345,25 +345,55 @@ button:disabled {
     transform: scale(1);
 }
 
-.delete-button, .torrent-button {
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
+.action-buttons .icon-button {
+    width: 36px;
+    height: 36px;
     border: none;
-    background-color: rgba(0,0,0,0.6);
-    color: white;
-    font-size: 20px;
-    line-height: 30px;
-    text-align: center;
+    background: transparent;
     padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
-    transition: background-color 0.3s;
+    transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
-.delete-button:hover { background-color: var(--danger-color); }
-.torrent-button:hover { background-color: var(--torrent-color); }
-.torrent-button.status-downloading { background-color: var(--torrent-color); }
-.torrent-button.status-seeding, .torrent-button.status-completed { background-color: var(--torrent-done-color); }
+.action-buttons .icon-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.85);
+    outline-offset: 2px;
+    border-radius: 50%;
+}
+
+.action-buttons .icon-button svg {
+    width: 26px;
+    height: 26px;
+    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.55));
+    transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.action-buttons .icon-button:hover svg {
+    transform: translateY(-1px) scale(1.03);
+    filter: drop-shadow(0 5px 9px rgba(0, 0, 0, 0.6));
+}
+
+.action-buttons .icon-button:active svg {
+    transform: translateY(0) scale(0.97);
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.55));
+}
+
+.action-buttons .icon-button[disabled],
+.action-buttons .icon-button[disabled] svg {
+    cursor: not-allowed;
+    opacity: 0.55;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.35));
+}
+
+.icon-sprite {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+}
 
 .gallery-item img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform 0.4s ease, filter 0.4s ease; animation: reveal 0.5s ease-out forwards; }
 .gallery-item:hover img { transform: scale(1.05); filter: brightness(1.1); }

--- a/static/js/library.js
+++ b/static/js/library.js
@@ -465,15 +465,26 @@ document.addEventListener('DOMContentLoaded', () => {
         card.dataset.hasMagnet = normalized ? 'true' : 'false';
         card.dataset.magnetLink = magnetLink || '';
         const downloadBtn = card.querySelector('.download-button');
+        const searchBtn = card.querySelector('.search-button');
         const kinopoiskId = card.dataset.kinopoiskId;
+        const shouldShowDownload = normalized;
         if (downloadBtn) {
-            const canDownload = normalized && Boolean(kinopoiskId);
+            const canDownload = shouldShowDownload && Boolean(kinopoiskId);
+            downloadBtn.hidden = !shouldShowDownload;
             if (canDownload) {
                 downloadBtn.removeAttribute('disabled');
                 downloadBtn.title = 'Скачать торрент';
-            } else {
+            } else if (shouldShowDownload) {
                 downloadBtn.setAttribute('disabled', 'disabled');
-                downloadBtn.title = kinopoiskId ? 'Добавьте magnet-ссылку, чтобы скачать' : 'kinopoisk_id не указан';
+                downloadBtn.title = kinopoiskId ? 'Добавьте magnet-ссылку, чтобы скачать' : 'Для этого фильма не указан kinopoisk_id';
+            } else {
+                downloadBtn.removeAttribute('disabled');
+            }
+        }
+        if (searchBtn) {
+            searchBtn.hidden = shouldShowDownload;
+            if (!shouldShowDownload) {
+                searchBtn.title = 'Искать торрент';
             }
         }
     };
@@ -652,22 +663,30 @@ document.addEventListener('DOMContentLoaded', () => {
             const card = event.target.closest('.gallery-item');
             if (!card) return;
 
-            if (event.target.classList.contains('download-button')) {
-                event.stopPropagation();
-                handleDownload(card);
-                return;
-            }
+            const actionButton = event.target.closest('button');
+            if (actionButton && card.contains(actionButton)) {
+                if (actionButton.disabled) {
+                    event.stopPropagation();
+                    return;
+                }
 
-            if (event.target.classList.contains('search-button')) {
-                event.stopPropagation();
-                handleSearch(card.dataset.movieName, card.dataset.movieYear);
-                return;
-            }
+                if (actionButton.classList.contains('download-button')) {
+                    event.stopPropagation();
+                    handleDownload(card);
+                    return;
+                }
 
-            if (event.target.classList.contains('delete-button')) {
-                event.stopPropagation();
-                handleDelete(card);
-                return;
+                if (actionButton.classList.contains('search-button')) {
+                    event.stopPropagation();
+                    handleSearch(card.dataset.movieName, card.dataset.movieYear);
+                    return;
+                }
+
+                if (actionButton.classList.contains('delete-button')) {
+                    event.stopPropagation();
+                    handleDelete(card);
+                    return;
+                }
             }
 
             renderModal(card);

--- a/templates/history.html
+++ b/templates/history.html
@@ -21,6 +21,47 @@
         </div>
     </header>
 
+    <svg class="icon-sprite" aria-hidden="true" focusable="false">
+        <defs>
+            <linearGradient id="icon-download-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stop-color="#5be5d5"/>
+                <stop offset="100%" stop-color="#1c8b79"/>
+            </linearGradient>
+            <linearGradient id="icon-download-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8"/>
+                <stop offset="100%" stop-color="#0f5a4c" stop-opacity="0.9"/>
+            </linearGradient>
+            <linearGradient id="icon-download-base" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stop-color="#8fffe8" stop-opacity="0.95"/>
+                <stop offset="100%" stop-color="#1a6c5c" stop-opacity="0.95"/>
+            </linearGradient>
+            <linearGradient id="icon-search-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#ffe17d"/>
+                <stop offset="100%" stop-color="#d1970c"/>
+            </linearGradient>
+            <linearGradient id="icon-search-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#fff5c7" stop-opacity="0.9"/>
+                <stop offset="100%" stop-color="#7b4b00" stop-opacity="0.9"/>
+            </linearGradient>
+            <linearGradient id="icon-delete-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#ff9b9b"/>
+                <stop offset="100%" stop-color="#d62828"/>
+            </linearGradient>
+        </defs>
+        <symbol id="icon-download" viewBox="0 0 36 36">
+            <path d="M18 4a1.2 1.2 0 0 0-1.2 1.2v13.07l-4.18-4.18a1.2 1.2 0 1 0-1.7 1.7l6.48 6.49a1.2 1.2 0 0 0 1.7 0l6.48-6.49a1.2 1.2 0 1 0-1.7-1.7l-4.18 4.18V5.2A1.2 1.2 0 0 0 18 4Z" fill="url(#icon-download-gradient)" stroke="url(#icon-download-stroke)" stroke-width="1.2" stroke-linejoin="round"/>
+            <path d="M9.5 24.5h17a1.5 1.5 0 0 1 0 3h-17a1.5 1.5 0 0 1 0-3Z" fill="url(#icon-download-base)" stroke="url(#icon-download-stroke)" stroke-width="1" stroke-linecap="round"/>
+        </symbol>
+        <symbol id="icon-search" viewBox="0 0 36 36">
+            <circle cx="15" cy="15" r="8" fill="url(#icon-search-gradient)" stroke="url(#icon-search-stroke)" stroke-width="1.4"/>
+            <path d="M20.6 20.6 27.5 27.5" stroke="url(#icon-search-stroke)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        </symbol>
+        <symbol id="icon-delete" viewBox="0 0 36 36">
+            <path d="M11 11 25 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
+            <path d="M25 11 11 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
+        </symbol>
+    </svg>
+
     <div class="history-gallery">
         {% for lottery in lotteries %}
             {% if lottery.result_name %}
@@ -43,12 +84,23 @@
                     <div class="action-buttons">
                         {# ИЗМЕНЕНИЕ: Проверяем наличие идентификатора в словаре #}
                         {% if has_identifier %}
-                            <button class="action-button download-button" title="Скачать фильм">&#x2913;</button>
+                            <button type="button" class="icon-button download-button" title="Скачать фильм" aria-label="Скачать фильм">
+                                <svg class="icon-svg icon-download" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                    <use href="#icon-download"></use>
+                                </svg>
+                            </button>
                         {% else %}
-                            <button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>
+                            <button type="button" class="icon-button search-button" title="Искать торрент" aria-label="Искать торрент">
+                                <svg class="icon-svg icon-search" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                    <use href="#icon-search"></use>
+                                </svg>
+                            </button>
                         {% endif %}
-                        <button class="action-button library-button" title="Добавить в библиотеку">&#128218;</button>
-                        <button class="action-button-delete delete-button" title="Удалить лотерею">&times;</button>
+                        <button type="button" class="icon-button delete-button" title="Удалить лотерею" aria-label="Удалить лотерею">
+                            <svg class="icon-svg icon-delete" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                <use href="#icon-delete"></use>
+                            </svg>
+                        </button>
                     </div>
                     <div class="date-badge" data-date="{{ lottery.created_at.isoformat() }}"></div>
                     <img src="{{ lottery.result_poster or 'https://via.placeholder.com/200x300.png?text=No+Image' }}" alt="{{ lottery.result_name }}">
@@ -57,7 +109,11 @@
                 {# --- КАРТОЧКА ДЛЯ ОЖИДАЮЩЕЙ ЛОТЕРЕИ --- #}
                 <div class="gallery-item waiting-card" data-lottery-id="{{ lottery.id }}">
                     <div class="action-buttons">
-                         <button class="action-button-delete delete-button" title="Удалить лотерею">&times;</button>
+                         <button type="button" class="icon-button delete-button" title="Удалить лотерею" aria-label="Удалить лотерею">
+                            <svg class="icon-svg icon-delete" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                <use href="#icon-delete"></use>
+                            </svg>
+                        </button>
                     </div>
                     <div class="waiting-content">
                         <div class="loader-small"></div>

--- a/templates/library.html
+++ b/templates/library.html
@@ -20,6 +20,47 @@
         </div>
     </header>
 
+    <svg class="icon-sprite" aria-hidden="true" focusable="false">
+        <defs>
+            <linearGradient id="icon-download-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stop-color="#5be5d5"/>
+                <stop offset="100%" stop-color="#1c8b79"/>
+            </linearGradient>
+            <linearGradient id="icon-download-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8"/>
+                <stop offset="100%" stop-color="#0f5a4c" stop-opacity="0.9"/>
+            </linearGradient>
+            <linearGradient id="icon-download-base" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stop-color="#8fffe8" stop-opacity="0.95"/>
+                <stop offset="100%" stop-color="#1a6c5c" stop-opacity="0.95"/>
+            </linearGradient>
+            <linearGradient id="icon-search-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#ffe17d"/>
+                <stop offset="100%" stop-color="#d1970c"/>
+            </linearGradient>
+            <linearGradient id="icon-search-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#fff5c7" stop-opacity="0.9"/>
+                <stop offset="100%" stop-color="#7b4b00" stop-opacity="0.9"/>
+            </linearGradient>
+            <linearGradient id="icon-delete-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#ff9b9b"/>
+                <stop offset="100%" stop-color="#d62828"/>
+            </linearGradient>
+        </defs>
+        <symbol id="icon-download" viewBox="0 0 36 36">
+            <path d="M18 4a1.2 1.2 0 0 0-1.2 1.2v13.07l-4.18-4.18a1.2 1.2 0 1 0-1.7 1.7l6.48 6.49a1.2 1.2 0 0 0 1.7 0l6.48-6.49a1.2 1.2 0 1 0-1.7-1.7l-4.18 4.18V5.2A1.2 1.2 0 0 0 18 4Z" fill="url(#icon-download-gradient)" stroke="url(#icon-download-stroke)" stroke-width="1.2" stroke-linejoin="round"/>
+            <path d="M9.5 24.5h17a1.5 1.5 0 0 1 0 3h-17a1.5 1.5 0 0 1 0-3Z" fill="url(#icon-download-base)" stroke="url(#icon-download-stroke)" stroke-width="1" stroke-linecap="round"/>
+        </symbol>
+        <symbol id="icon-search" viewBox="0 0 36 36">
+            <circle cx="15" cy="15" r="8" fill="url(#icon-search-gradient)" stroke="url(#icon-search-stroke)" stroke-width="1.4"/>
+            <path d="M20.6 20.6 27.5 27.5" stroke="url(#icon-search-stroke)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        </symbol>
+        <symbol id="icon-delete" viewBox="0 0 36 36">
+            <path d="M11 11 25 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
+            <path d="M25 11 11 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
+        </symbol>
+    </svg>
+
     <div class="history-gallery library-gallery">
         {% if library_movies %}
             {% for movie in library_movies %}
@@ -39,9 +80,38 @@
                     data-magnet-link="{{ (movie.magnet_link or '')|e }}"
                 >
                     <div class="action-buttons">
-                        <button class="action-button download-button" title="Скачать торрент">&#x2913;</button>
-                        <button class="action-button search-button" title="Искать торрент">&#x1F50D;</button>
-                        <button class="action-button-delete delete-button" title="Удалить из библиотеки">&times;</button>
+                        <button
+                            type="button"
+                            class="icon-button download-button"
+                            title="Скачать торрент"
+                            aria-label="Скачать торрент"
+                            {% if not movie.has_magnet %}hidden{% endif %}
+                        >
+                            <svg class="icon-svg icon-download" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                <use href="#icon-download"></use>
+                            </svg>
+                        </button>
+                        <button
+                            type="button"
+                            class="icon-button search-button"
+                            title="Искать торрент"
+                            aria-label="Искать торрент"
+                            {% if movie.has_magnet %}hidden{% endif %}
+                        >
+                            <svg class="icon-svg icon-search" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                <use href="#icon-search"></use>
+                            </svg>
+                        </button>
+                        <button
+                            type="button"
+                            class="icon-button delete-button"
+                            title="Удалить из библиотеки"
+                            aria-label="Удалить из библиотеки"
+                        >
+                            <svg class="icon-svg icon-delete" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                <use href="#icon-delete"></use>
+                            </svg>
+                        </button>
                     </div>
                     <div class="date-badge" data-date="{{ movie.added_at.isoformat() }}"></div>
                     <img src="{{ movie.poster or 'https://via.placeholder.com/200x300.png?text=No+Image' }}" alt="{{ movie.name|e }}">


### PR DESCRIPTION
## Summary
- add shared SVG sprite and new icon buttons for the library and history views
- toggle search/download visibility based on magnet links and remove the redundant add-to-library shortcut
- refresh icon styling and update event handling to support the new markup

## Testing
- pytest *(fails: tests/test_torrent_status.py contains merge conflict markers in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdf1dc72c8328ad80c006eca24b5b