### PR TITLE
Restyle action icons for better contrast

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -346,17 +346,24 @@ button:disabled {
 }
 
 .action-buttons .icon-button {
-    width: 36px;
-    height: 36px;
+    width: 38px;
+    height: 38px;
     border: none;
-    background: transparent;
     padding: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    transition: transform 0.2s ease, opacity 0.2s ease;
+    border-radius: 50%;
+    background: rgba(17, 19, 24, 0.72);
+    backdrop-filter: blur(8px);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+    transition: transform 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
+
+.action-buttons .icon-button.download-button { color: #44dac4; }
+.action-buttons .icon-button.search-button { color: #f7c654; }
+.action-buttons .icon-button.delete-button { color: #ff7b7b; }
 
 .action-buttons .icon-button:focus-visible {
     outline: 2px solid rgba(255, 255, 255, 0.85);
@@ -365,27 +372,38 @@ button:disabled {
 }
 
 .action-buttons .icon-button svg {
-    width: 26px;
-    height: 26px;
-    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.55));
-    transition: transform 0.2s ease, filter 0.2s ease;
+    width: 22px;
+    height: 22px;
+    transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .action-buttons .icon-button:hover svg {
-    transform: translateY(-1px) scale(1.03);
-    filter: drop-shadow(0 5px 9px rgba(0, 0, 0, 0.6));
+    transform: translateY(-1px) scale(1.05);
 }
 
 .action-buttons .icon-button:active svg {
-    transform: translateY(0) scale(0.97);
-    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.55));
+    transform: translateY(0) scale(0.95);
 }
 
-.action-buttons .icon-button[disabled],
-.action-buttons .icon-button[disabled] svg {
+.action-buttons .icon-button:hover {
+    background: rgba(25, 28, 34, 0.82);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.45);
+}
+
+.action-buttons .icon-button:active {
+    background: rgba(25, 28, 34, 0.66);
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+}
+
+.action-buttons .icon-button[disabled] {
     cursor: not-allowed;
     opacity: 0.55;
-    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.35));
+    background: rgba(20, 23, 29, 0.55);
+    box-shadow: none;
+}
+
+.action-buttons .icon-button[disabled] svg {
+    opacity: 1;
 }
 
 .icon-sprite {

--- a/templates/history.html
+++ b/templates/history.html
@@ -22,43 +22,18 @@
     </header>
 
     <svg class="icon-sprite" aria-hidden="true" focusable="false">
-        <defs>
-            <linearGradient id="icon-download-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" stop-color="#5be5d5"/>
-                <stop offset="100%" stop-color="#1c8b79"/>
-            </linearGradient>
-            <linearGradient id="icon-download-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="#0f5a4c" stop-opacity="0.9"/>
-            </linearGradient>
-            <linearGradient id="icon-download-base" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" stop-color="#8fffe8" stop-opacity="0.95"/>
-                <stop offset="100%" stop-color="#1a6c5c" stop-opacity="0.95"/>
-            </linearGradient>
-            <linearGradient id="icon-search-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#ffe17d"/>
-                <stop offset="100%" stop-color="#d1970c"/>
-            </linearGradient>
-            <linearGradient id="icon-search-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#fff5c7" stop-opacity="0.9"/>
-                <stop offset="100%" stop-color="#7b4b00" stop-opacity="0.9"/>
-            </linearGradient>
-            <linearGradient id="icon-delete-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#ff9b9b"/>
-                <stop offset="100%" stop-color="#d62828"/>
-            </linearGradient>
-        </defs>
-        <symbol id="icon-download" viewBox="0 0 36 36">
-            <path d="M18 4a1.2 1.2 0 0 0-1.2 1.2v13.07l-4.18-4.18a1.2 1.2 0 1 0-1.7 1.7l6.48 6.49a1.2 1.2 0 0 0 1.7 0l6.48-6.49a1.2 1.2 0 1 0-1.7-1.7l-4.18 4.18V5.2A1.2 1.2 0 0 0 18 4Z" fill="url(#icon-download-gradient)" stroke="url(#icon-download-stroke)" stroke-width="1.2" stroke-linejoin="round"/>
-            <path d="M9.5 24.5h17a1.5 1.5 0 0 1 0 3h-17a1.5 1.5 0 0 1 0-3Z" fill="url(#icon-download-base)" stroke="url(#icon-download-stroke)" stroke-width="1" stroke-linecap="round"/>
+        <symbol id="icon-download" viewBox="0 0 24 24">
+            <path d="M12 4v10" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="m7.5 10.5 4.5 4.5 4.5-4.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M5 18.5h14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
         </symbol>
-        <symbol id="icon-search" viewBox="0 0 36 36">
-            <circle cx="15" cy="15" r="8" fill="url(#icon-search-gradient)" stroke="url(#icon-search-stroke)" stroke-width="1.4"/>
-            <path d="M20.6 20.6 27.5 27.5" stroke="url(#icon-search-stroke)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <symbol id="icon-search" viewBox="0 0 24 24">
+            <circle cx="11" cy="11" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8"/>
+            <path d="m16 16 4 4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
         </symbol>
-        <symbol id="icon-delete" viewBox="0 0 36 36">
-            <path d="M11 11 25 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
-            <path d="M25 11 11 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
+        <symbol id="icon-delete" viewBox="0 0 24 24">
+            <path d="M6 6 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M18 6 6 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
         </symbol>
     </svg>
 
@@ -85,19 +60,19 @@
                         {# ИЗМЕНЕНИЕ: Проверяем наличие идентификатора в словаре #}
                         {% if has_identifier %}
                             <button type="button" class="icon-button download-button" title="Скачать фильм" aria-label="Скачать фильм">
-                                <svg class="icon-svg icon-download" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                            <svg class="icon-svg icon-download" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                     <use href="#icon-download"></use>
                                 </svg>
                             </button>
                         {% else %}
                             <button type="button" class="icon-button search-button" title="Искать торрент" aria-label="Искать торрент">
-                                <svg class="icon-svg icon-search" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                                <svg class="icon-svg icon-search" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                     <use href="#icon-search"></use>
                                 </svg>
                             </button>
                         {% endif %}
                         <button type="button" class="icon-button delete-button" title="Удалить лотерею" aria-label="Удалить лотерею">
-                            <svg class="icon-svg icon-delete" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                            <svg class="icon-svg icon-delete" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <use href="#icon-delete"></use>
                             </svg>
                         </button>
@@ -110,7 +85,7 @@
                 <div class="gallery-item waiting-card" data-lottery-id="{{ lottery.id }}">
                     <div class="action-buttons">
                          <button type="button" class="icon-button delete-button" title="Удалить лотерею" aria-label="Удалить лотерею">
-                            <svg class="icon-svg icon-delete" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                            <svg class="icon-svg icon-delete" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <use href="#icon-delete"></use>
                             </svg>
                         </button>

--- a/templates/library.html
+++ b/templates/library.html
@@ -21,43 +21,18 @@
     </header>
 
     <svg class="icon-sprite" aria-hidden="true" focusable="false">
-        <defs>
-            <linearGradient id="icon-download-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" stop-color="#5be5d5"/>
-                <stop offset="100%" stop-color="#1c8b79"/>
-            </linearGradient>
-            <linearGradient id="icon-download-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8"/>
-                <stop offset="100%" stop-color="#0f5a4c" stop-opacity="0.9"/>
-            </linearGradient>
-            <linearGradient id="icon-download-base" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" stop-color="#8fffe8" stop-opacity="0.95"/>
-                <stop offset="100%" stop-color="#1a6c5c" stop-opacity="0.95"/>
-            </linearGradient>
-            <linearGradient id="icon-search-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#ffe17d"/>
-                <stop offset="100%" stop-color="#d1970c"/>
-            </linearGradient>
-            <linearGradient id="icon-search-stroke" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#fff5c7" stop-opacity="0.9"/>
-                <stop offset="100%" stop-color="#7b4b00" stop-opacity="0.9"/>
-            </linearGradient>
-            <linearGradient id="icon-delete-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="#ff9b9b"/>
-                <stop offset="100%" stop-color="#d62828"/>
-            </linearGradient>
-        </defs>
-        <symbol id="icon-download" viewBox="0 0 36 36">
-            <path d="M18 4a1.2 1.2 0 0 0-1.2 1.2v13.07l-4.18-4.18a1.2 1.2 0 1 0-1.7 1.7l6.48 6.49a1.2 1.2 0 0 0 1.7 0l6.48-6.49a1.2 1.2 0 1 0-1.7-1.7l-4.18 4.18V5.2A1.2 1.2 0 0 0 18 4Z" fill="url(#icon-download-gradient)" stroke="url(#icon-download-stroke)" stroke-width="1.2" stroke-linejoin="round"/>
-            <path d="M9.5 24.5h17a1.5 1.5 0 0 1 0 3h-17a1.5 1.5 0 0 1 0-3Z" fill="url(#icon-download-base)" stroke="url(#icon-download-stroke)" stroke-width="1" stroke-linecap="round"/>
+        <symbol id="icon-download" viewBox="0 0 24 24">
+            <path d="M12 4v10" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="m7.5 10.5 4.5 4.5 4.5-4.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M5 18.5h14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
         </symbol>
-        <symbol id="icon-search" viewBox="0 0 36 36">
-            <circle cx="15" cy="15" r="8" fill="url(#icon-search-gradient)" stroke="url(#icon-search-stroke)" stroke-width="1.4"/>
-            <path d="M20.6 20.6 27.5 27.5" stroke="url(#icon-search-stroke)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <symbol id="icon-search" viewBox="0 0 24 24">
+            <circle cx="11" cy="11" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8"/>
+            <path d="m16 16 4 4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
         </symbol>
-        <symbol id="icon-delete" viewBox="0 0 36 36">
-            <path d="M11 11 25 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
-            <path d="M25 11 11 25" stroke="url(#icon-delete-gradient)" stroke-width="3.2" stroke-linecap="round"/>
+        <symbol id="icon-delete" viewBox="0 0 24 24">
+            <path d="M6 6 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M18 6 6 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
         </symbol>
     </svg>
 
@@ -87,7 +62,7 @@
                             aria-label="Скачать торрент"
                             {% if not movie.has_magnet %}hidden{% endif %}
                         >
-                            <svg class="icon-svg icon-download" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                            <svg class="icon-svg icon-download" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <use href="#icon-download"></use>
                             </svg>
                         </button>
@@ -98,7 +73,7 @@
                             aria-label="Искать торрент"
                             {% if movie.has_magnet %}hidden{% endif %}
                         >
-                            <svg class="icon-svg icon-search" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                            <svg class="icon-svg icon-search" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <use href="#icon-search"></use>
                             </svg>
                         </button>
@@ -108,7 +83,7 @@
                             title="Удалить из библиотеки"
                             aria-label="Удалить из библиотеки"
                         >
-                            <svg class="icon-svg icon-delete" viewBox="0 0 36 36" aria-hidden="true" focusable="false">
+                            <svg class="icon-svg icon-delete" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <use href="#icon-delete"></use>
                             </svg>
                         </button>


### PR DESCRIPTION
## Summary
- replace gradient SVG icons in the library and history pages with unified line icons that inherit button colors
- give action buttons a rounded, translucent backdrop with hover and disabled states so the controls stay legible over posters
- align inline SVG viewBoxes with the updated sprite size

## Testing
- pytest *(fails: SyntaxError in tests/test_torrent_status.py due to invalid literal in repository-provided test)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe6b48c388328a4a295b71d3188df