### PR TITLE
Unify action icon behavior and magnet handling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,6 +11,7 @@
     --rating-high: #28a745; /* Зеленый для высокого рейтинга */
     --rating-medium: #fd7e14; /* Оранжевый для среднего */
     --rating-low: #6c757d; /* Серый для низкого */
+    --action-icon-color: #f1f5ff; /* Единый цвет иконок действий */
 }
 
 html {
@@ -359,11 +360,8 @@ button:disabled {
     backdrop-filter: blur(8px);
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
     transition: transform 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    color: var(--action-icon-color);
 }
-
-.action-buttons .icon-button.download-button { color: #44dac4; }
-.action-buttons .icon-button.search-button { color: #f7c654; }
-.action-buttons .icon-button.delete-button { color: #ff7b7b; }
 
 .action-buttons .icon-button:focus-visible {
     outline: 2px solid rgba(255, 255, 255, 0.85);

--- a/templates/history.html
+++ b/templates/history.html
@@ -55,22 +55,20 @@
                      data-movie-description="{{ (winner_movie.description|default('', true))|e if winner_movie else '' }}"
                      data-movie-rating="{{ '%.1f'|format(winner_movie.rating_kp) if winner_movie and winner_movie.rating_kp is not none else '' }}"
                      data-movie-genres="{{ (winner_movie.genres|default('', true))|e if winner_movie else '' }}"
-                     data-movie-countries="{{ (winner_movie.countries|default('', true))|e if winner_movie else '' }}">
+                     data-movie-countries="{{ (winner_movie.countries|default('', true))|e if winner_movie else '' }}"
+                     data-has-magnet="{{ 'true' if has_identifier else 'false' }}"
+                     data-magnet-link="{{ identifiers[winner_movie.kinopoisk_id].magnet_link|e if has_identifier else '' }}">
                     <div class="action-buttons">
-                        {# ИЗМЕНЕНИЕ: Проверяем наличие идентификатора в словаре #}
-                        {% if has_identifier %}
-                            <button type="button" class="icon-button download-button" title="Скачать фильм" aria-label="Скачать фильм">
+                        <button type="button" class="icon-button download-button" title="Скачать фильм" aria-label="Скачать фильм" {% if not has_identifier %}hidden{% endif %}>
                             <svg class="icon-svg icon-download" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                    <use href="#icon-download"></use>
-                                </svg>
-                            </button>
-                        {% else %}
-                            <button type="button" class="icon-button search-button" title="Искать торрент" aria-label="Искать торрент">
-                                <svg class="icon-svg icon-search" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                    <use href="#icon-search"></use>
-                                </svg>
-                            </button>
-                        {% endif %}
+                                <use href="#icon-download"></use>
+                            </svg>
+                        </button>
+                        <button type="button" class="icon-button search-button" title="Искать торрент" aria-label="Искать торрент" {% if has_identifier %}hidden{% endif %}>
+                            <svg class="icon-svg icon-search" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                <use href="#icon-search"></use>
+                            </svg>
+                        </button>
                         <button type="button" class="icon-button delete-button" title="Удалить лотерею" aria-label="Удалить лотерею">
                             <svg class="icon-svg icon-delete" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <use href="#icon-delete"></use>


### PR DESCRIPTION
## Summary
- make action icons share a single color theme across library and history views
- ensure history cards expose both download and search buttons and keep magnet metadata in sync with the backend
- align history modal behaviour with the library, including disabling page scroll when it is open

## Testing
- pip install -r requirements.txt
- pytest *(fails: SyntaxError raised while collecting tests/test_torrent_status.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cfea4590b88328900423dd964ed181