### PR TITLE
Stop polling removed waiting lotteries

### DIFF
--- a/static/js/history.js
+++ b/static/js/history.js
@@ -695,6 +695,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (response.ok && data.success) {
                 cardElement.classList.add('is-deleting');
                 removeDownload(lotteryId, cardElement.dataset.kinopoiskId);
+                if (waitingCards.has(lotteryId)) {
+                    waitingCards.delete(lotteryId);
+                }
                 setTimeout(() => {
                     cardElement.remove();
                     formatDateBadges();
@@ -910,6 +913,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             } catch (error) {
                 console.error('Не удалось обновить лотерею', lotteryId, error);
+                map.delete(lotteryId);
             }
         });
 


### PR DESCRIPTION
## Summary
- stop polling waiting lotteries after they are deleted from the history page
- end polling loops when lottery result fetching fails to avoid repeated errors

## Testing
- pytest *(fails: SyntaxError in tests/test_torrent_status.py due to invalid test content)*

------
https://chatgpt.com/codex/tasks/task_e_68cff8b21960832896db34b4e2ec2805